### PR TITLE
No Reset pins if Acquire or Release a provider

### DIFF
--- a/Targets/STM32F4/STM32F4_AD.cpp
+++ b/Targets/STM32F4/STM32F4_AD.cpp
@@ -69,10 +69,16 @@ const TinyCLR_Api_Info* STM32F4_Adc_GetApi() {
 }
 
 TinyCLR_Result STM32F4_Adc_Acquire(const TinyCLR_Adc_Provider* self) {
+    if (self == nullptr)
+        return TinyCLR_Result::ArgumentNull;
+
     return TinyCLR_Result::Success;
 }
 
 TinyCLR_Result STM32F4_Adc_Release(const TinyCLR_Adc_Provider* self) {
+    if (self == nullptr)
+        return TinyCLR_Result::ArgumentNull;
+
     return TinyCLR_Result::Success;
 }
 

--- a/Targets/STM32F4/STM32F4_DA.cpp
+++ b/Targets/STM32F4/STM32F4_DA.cpp
@@ -50,10 +50,16 @@ const TinyCLR_Api_Info* STM32F4_Dac_GetApi() {
 }
 
 TinyCLR_Result STM32F4_Dac_Acquire(const TinyCLR_Dac_Provider* self) {
+    if (self == nullptr)
+        return TinyCLR_Result::ArgumentNull;
+
     return TinyCLR_Result::Success;
 }
 
 TinyCLR_Result STM32F4_Dac_Release(const TinyCLR_Dac_Provider* self) {
+    if (self == nullptr)
+        return TinyCLR_Result::ArgumentNull;
+
     return TinyCLR_Result::Success;
 }
 

--- a/Targets/STM32F4/STM32F4_GPIO.cpp
+++ b/Targets/STM32F4/STM32F4_GPIO.cpp
@@ -34,7 +34,7 @@ struct STM32F4_Int_State {
     TinyCLR_Gpio_PinValue                  currentValue;
 };
 
-static uint8_t                     g_pinReserved[STM32F4_Gpio_MaxPins]; //  1 bit per pin
+static bool                     g_pinReserved[STM32F4_Gpio_MaxPins]; //  1 bit per pin
 static uint32_t                         g_debounceTicksPin[STM32F4_Gpio_MaxPins];
 static STM32F4_Int_State            g_int_state[STM32F4_Gpio_MaxInt]; // interrupt state
 static TinyCLR_Gpio_PinDriveMode     g_pinDriveMode[STM32F4_Gpio_MaxPins];
@@ -223,10 +223,13 @@ bool STM32F4_Gpio_DisableInterrupt(uint32_t pin) {
 }
 
 bool STM32F4_Gpio_OpenPin(int32_t pin) {
-    if (g_pinReserved[pin] == STM32F4_Gpio_PinReserved)
+    if (pin >= STM32F4_Gpio_MaxPins || pin == GPIO_PIN_NONE)
         return false;
 
-    g_pinReserved[pin] |= STM32F4_Gpio_PinReserved;
+    if (g_pinReserved[pin])
+        return false;
+
+    g_pinReserved[pin] = true;
 
     return true;
 }
@@ -234,7 +237,8 @@ bool STM32F4_Gpio_OpenPin(int32_t pin) {
 bool STM32F4_Gpio_ClosePin(int32_t pin) {
     if (pin >= STM32F4_Gpio_MaxPins || pin == GPIO_PIN_NONE)
         return false;
-    g_pinReserved[pin] &= ~STM32F4_Gpio_PinReserved;
+
+    g_pinReserved[pin] = false;
 
     // reset to default state
     return STM32F4_Gpio_ConfigurePin(pin, STM32F4_Gpio_PortMode::Input, STM32F4_Gpio_OutputType::PushPull, STM32F4_Gpio_OutputSpeed::High, STM32F4_Gpio_PullDirection::None, STM32F4_Gpio_AlternateFunction::AF0);

--- a/Targets/STM32F4/STM32F4_I2C.cpp
+++ b/Targets/STM32F4/STM32F4_I2C.cpp
@@ -362,6 +362,9 @@ TinyCLR_Result STM32F4_I2c_SetActiveSettings(const TinyCLR_I2c_Provider* self, i
 TinyCLR_Result STM32F4_I2c_Acquire(const TinyCLR_I2c_Provider* self) {
     STM32F4_Gpio_AlternateFunction altMode = (STM32F4_I2C_PORT == 2 && STM32F4_I2C_SDA_PIN == 25) ? STM32F4_Gpio_AlternateFunction::AF9 : STM32F4_Gpio_AlternateFunction::AF4;
 
+    if (self == nullptr)
+        return TinyCLR_Result::ArgumentNull;
+
     if (!STM32F4_Gpio_OpenPin(STM32F4_I2C_SDA_PIN) || !STM32F4_Gpio_OpenPin(STM32F4_I2C_SCL_PIN))
         return TinyCLR_Result::SharingViolation;
 
@@ -386,6 +389,8 @@ TinyCLR_Result STM32F4_I2c_Acquire(const TinyCLR_I2c_Provider* self) {
 }
 
 TinyCLR_Result STM32F4_I2c_Release(const TinyCLR_I2c_Provider* self) {
+    if (self == nullptr)
+        return TinyCLR_Result::ArgumentNull;
 
     STM32F4_Interrupt_Deactivate(I2Cx_EV_IRQn);
     STM32F4_Interrupt_Deactivate(I2Cx_ER_IRQn);

--- a/Targets/STM32F4/STM32F4_PWM.cpp
+++ b/Targets/STM32F4/STM32F4_PWM.cpp
@@ -388,17 +388,15 @@ TinyCLR_Result STM32F4_Pwm_SetDesiredFrequency(const TinyCLR_Pwm_Provider* self,
 }
 
 TinyCLR_Result STM32F4_Pwm_Acquire(const TinyCLR_Pwm_Provider* self) {
-    if (self == nullptr) return TinyCLR_Result::ArgumentNull;
-
-    STM32F4_Pwm_ResetController(self->Index);
+    if (self == nullptr)
+        return TinyCLR_Result::ArgumentNull;
 
     return TinyCLR_Result::Success;
 }
 
 TinyCLR_Result STM32F4_Pwm_Release(const TinyCLR_Pwm_Provider* self) {
-    if (self == nullptr) return TinyCLR_Result::ArgumentNull;
-
-    STM32F4_Pwm_ResetController(self->Index);
+    if (self == nullptr)
+        return TinyCLR_Result::ArgumentNull;
 
     return TinyCLR_Result::Success;
 }

--- a/Targets/STM32F4/STM32F4_PWM.cpp
+++ b/Targets/STM32F4/STM32F4_PWM.cpp
@@ -402,23 +402,20 @@ TinyCLR_Result STM32F4_Pwm_Release(const TinyCLR_Pwm_Provider* self) {
 }
 
 void STM32F4_Pwm_Reset() {
-    for (auto index = 0; index < TOTAL_PWM_CONTROLLER; index++)
-        STM32F4_Pwm_ResetController(index);
-}
+    for (auto controller = 0; controller < TOTAL_PWM_CONTROLLER; controller++) {
+        for (int p = 0; p < MAX_PWM_PER_CONTROLLER; p++) {
+            if (pwmController(controller).gpioPin[p] != GPIO_PIN_NONE) {
+                STM32F4_Pwm_DisablePin(pwmProviders[controller], p);
+                STM32F4_Pwm_ReleasePin(pwmProviders[controller], p);
 
-void STM32F4_Pwm_ResetController(int32_t controller) {
-    for (int p = 0; p < MAX_PWM_PER_CONTROLLER; p++) {
-        if (pwmController(controller).gpioPin[p] != GPIO_PIN_NONE) {
-            STM32F4_Pwm_DisablePin(pwmProviders[controller], p);
-            STM32F4_Pwm_ReleasePin(pwmProviders[controller], p);
-
-            pwmController(controller).dutyCycle[p] = 0;
-            pwmController(controller).invert[p] = false;
+                pwmController(controller).dutyCycle[p] = 0;
+                pwmController(controller).invert[p] = false;
+            }
         }
-    }
 
-    pwmController(controller).theoryFreq = 0;
-    pwmController(controller).actualFreq = 0;
-    pwmController(controller).period = 0;
-    pwmController(controller).presc = 0;
+        pwmController(controller).theoryFreq = 0;
+        pwmController(controller).actualFreq = 0;
+        pwmController(controller).period = 0;
+        pwmController(controller).presc = 0;
+    }
 }

--- a/Targets/STM32F4/STM32F4_SPI.cpp
+++ b/Targets/STM32F4/STM32F4_SPI.cpp
@@ -106,7 +106,7 @@ bool STM32F4_Spi_Transaction_Start(int32_t controller) {
     case 5:
         RCC->APB2ENR |= RCC_APB2ENR_SPI6EN;
         break; // enable SPI6 clock
-#endif        
+#endif
     }
 
     ptr_SPI_TypeDef spi = g_STM32_Spi_Port[controller];
@@ -189,7 +189,6 @@ bool STM32F4_Spi_Transaction_Stop(int32_t controller) {
     while (spi->SR & SPI_SR_BSY); // wait for completion
 
     spi->CR1 = 0; // disable SPI
-
 
     STM32F4_Gpio_WritePin(g_SpiController[controller].ChipSelectLine, true);
 
@@ -442,6 +441,10 @@ TinyCLR_Result STM32F4_Spi_Write(const TinyCLR_Spi_Provider* self, const uint8_t
 TinyCLR_Result STM32F4_Spi_SetActiveSettings(const TinyCLR_Spi_Provider* self, int32_t chipSelectLine, int32_t clockFrequency, int32_t dataBitLength, TinyCLR_Spi_Mode mode) {
     int32_t controller = (self->Index);
 
+    int32_t clkPin = g_STM32F4_Spi_Sclk_Pins[controller];
+    int32_t misoPin = g_STM32F4_Spi_Miso_Pins[controller];
+    int32_t mosiPin = g_STM32F4_Spi_Mosi_Pins[controller];
+
     if (controller >= TOTAL_SPI_CONTROLLERS)
         return TinyCLR_Result::InvalidOperation;
 
@@ -450,6 +453,13 @@ TinyCLR_Result STM32F4_Spi_SetActiveSettings(const TinyCLR_Spi_Provider* self, i
     g_SpiController[controller].DataBitLength = dataBitLength;
     g_SpiController[controller].Mode = mode;
 
+    // Check each pin single time make sure once fail not effect to other pins
+    if (STM32F4_Gpio_OpenPin(clkPin) && STM32F4_Gpio_OpenPin(misoPin) && STM32F4_Gpio_OpenPin(mosiPin))
+        return TinyCLR_Result::Success;
+
+    if (g_SpiController[controller].ChipSelectLine == GPIO_PIN_NONE) // For case no need CS. CS always high
+        return TinyCLR_Result::Success;
+
     if (STM32F4_Gpio_OpenPin(g_SpiController[controller].ChipSelectLine))
         return TinyCLR_Result::Success;
 
@@ -457,35 +467,48 @@ TinyCLR_Result STM32F4_Spi_SetActiveSettings(const TinyCLR_Spi_Provider* self, i
 }
 
 TinyCLR_Result STM32F4_Spi_Acquire(const TinyCLR_Spi_Provider* self) {
+    if (self == nullptr)
+        return TinyCLR_Result::ArgumentNull;
+
     int32_t controller = (self->Index);
 
-    int32_t clkPin = g_STM32F4_Spi_Sclk_Pins[controller];
-    int32_t misoPin = g_STM32F4_Spi_Miso_Pins[controller];
-    int32_t mosiPin = g_STM32F4_Spi_Mosi_Pins[controller];
-
     g_SpiController[controller].ChipSelectLine = GPIO_PIN_NONE;
-
-    // Check each pin single time make sure once fail not effect to other pins
-    if (STM32F4_Gpio_OpenPin(clkPin) && STM32F4_Gpio_OpenPin(misoPin) && STM32F4_Gpio_OpenPin(mosiPin))
-        return TinyCLR_Result::Success;
 
     return TinyCLR_Result::NotAvailable;
 }
 
 TinyCLR_Result STM32F4_Spi_Release(const TinyCLR_Spi_Provider* self) {
+    if (self == nullptr)
+        return TinyCLR_Result::ArgumentNull;
+
     int32_t controller = (self->Index);
 
-    int32_t clkPin = g_STM32F4_Spi_Sclk_Pins[controller];
-    int32_t misoPin = g_STM32F4_Spi_Miso_Pins[controller];
-    int32_t mosiPin = g_STM32F4_Spi_Mosi_Pins[controller];
+    switch (controller) {
+    case 0:
+        RCC->APB2ENR &= ~RCC_APB2ENR_SPI1EN;
+        break; // disable SPI1 clock
 
-    // Check each pin single time make sure once fail not effect to other pins
-    STM32F4_Gpio_ClosePin(clkPin);
-    STM32F4_Gpio_ClosePin(misoPin);
-    STM32F4_Gpio_ClosePin(mosiPin);
+    case 1:
+        RCC->APB1ENR &= ~RCC_APB1ENR_SPI2EN;
+        break; // disable SPI2 clock
+#if TOTAL_SPI_CONTROLLERS > 2
+    case 2:
+        RCC->APB1ENR &= ~RCC_APB1ENR_SPI3EN;
+        break; // disable SPI3 clock
 
-    if (g_SpiController[controller].ChipSelectLine != GPIO_PIN_NONE)
-        STM32F4_Gpio_ClosePin(g_SpiController[controller].ChipSelectLine);
+    case 3:
+        RCC->APB2ENR &= ~RCC_APB2ENR_SPI4EN;
+        break; // disable SPI4 clock
+
+    case 4:
+        RCC->APB2ENR &= ~RCC_APB2ENR_SPI5EN;
+        break; // disable SPI5 clock
+
+    case 5:
+        RCC->APB2ENR &= ~RCC_APB2ENR_SPI6EN;
+        break; // disable SPI6 clock
+#endif
+    }
 
     return TinyCLR_Result::Success;
 }
@@ -537,6 +560,18 @@ TinyCLR_Result STM32F4_Spi_GetSupportedDataBitLengths(const TinyCLR_Spi_Provider
 
 void STM32F4_Spi_Reset() {
     for (auto i = 0; i < TOTAL_SPI_CONTROLLERS; i++) {
-        STM32F4_Spi_Release(spiProviders[i]);
+        int32_t controller = i;
+        int32_t clkPin = g_STM32F4_Spi_Sclk_Pins[controller];
+        int32_t misoPin = g_STM32F4_Spi_Miso_Pins[controller];
+        int32_t mosiPin = g_STM32F4_Spi_Mosi_Pins[controller];
+
+        STM32F4_Gpio_ClosePin(clkPin);
+        STM32F4_Gpio_ClosePin(misoPin);
+        STM32F4_Gpio_ClosePin(mosiPin);
+
+        if (g_SpiController[controller].ChipSelectLine != GPIO_PIN_NONE)
+            STM32F4_Gpio_ClosePin(g_SpiController[controller].ChipSelectLine);
+
+        STM32F4_Spi_Release(spiProviders[controller]);
     }
 }


### PR DESCRIPTION
A second issue here is, native code return a conflict if a pins is already used but no exception from managed code. That because in Library CLR (native code) we just call, no check return value.