### PR TITLE
Fixed #203. Access variable too early will return zero

### DIFF
--- a/Targets/AT91SAM9Rx64/AT91_USART.cpp
+++ b/Targets/AT91SAM9Rx64/AT91_USART.cpp
@@ -132,7 +132,7 @@ AT91_Gpio_PeripheralSelection AT91_Uart_GetCtsAlternateFunction(int32_t portNum)
 }
 
 TinyCLR_Result AT91_Uart_GetReadBufferSize(const TinyCLR_Uart_Provider* self, size_t& size) {
-    size = g_UartController[self->Index].rxBufferSize;
+    size = g_UartController[self->Index].rxBufferSize == 0 ? g_AT91_Uart_RxDefaultBuffersSize[self->Index] :  g_UartController[self->Index].rxBufferSize;
 
     return TinyCLR_Result::Success;
 }
@@ -161,7 +161,7 @@ TinyCLR_Result AT91_Uart_SetReadBufferSize(const TinyCLR_Uart_Provider* self, si
 }
 
 TinyCLR_Result AT91_Uart_GetWriteBufferSize(const TinyCLR_Uart_Provider* self, size_t& size) {
-    size = g_UartController[self->Index].txBufferSize;
+    size = g_UartController[self->Index].txBufferSize == 0 ? g_AT91_Uart_TxDefaultBuffersSize[self->Index] : g_UartController[self->Index].txBufferSize;
 
     return TinyCLR_Result::Success;
 }

--- a/Targets/AT91SAM9X35/AT91_USART.cpp
+++ b/Targets/AT91SAM9X35/AT91_USART.cpp
@@ -132,7 +132,7 @@ AT91_Gpio_PeripheralSelection AT91_Uart_GetCtsAlternateFunction(int32_t portNum)
 }
 
 TinyCLR_Result AT91_Uart_GetReadBufferSize(const TinyCLR_Uart_Provider* self, size_t& size) {
-    size = g_UartController[self->Index].rxBufferSize;
+    size = g_UartController[self->Index].rxBufferSize == 0 ? g_AT91_Uart_RxDefaultBuffersSize[self->Index] :  g_UartController[self->Index].rxBufferSize;
 
     return TinyCLR_Result::Success;
 }
@@ -161,7 +161,7 @@ TinyCLR_Result AT91_Uart_SetReadBufferSize(const TinyCLR_Uart_Provider* self, si
 }
 
 TinyCLR_Result AT91_Uart_GetWriteBufferSize(const TinyCLR_Uart_Provider* self, size_t& size) {
-    size = g_UartController[self->Index].txBufferSize;
+    size = g_UartController[self->Index].txBufferSize == 0 ? g_AT91_Uart_TxDefaultBuffersSize[self->Index] : g_UartController[self->Index].txBufferSize;
 
     return TinyCLR_Result::Success;
 }

--- a/Targets/LPC177x_LPC178x/LPC17_USART.cpp
+++ b/Targets/LPC177x_LPC178x/LPC17_USART.cpp
@@ -270,7 +270,7 @@ const TinyCLR_Api_Info* LPC17_Uart_GetApi() {
 }
 
 TinyCLR_Result LPC17_Uart_GetReadBufferSize(const TinyCLR_Uart_Provider* self, size_t& size) {
-    size = g_UartController[self->Index].rxBufferSize;
+    size = g_UartController[self->Index].rxBufferSize == 0 ? g_LPC17_Uart_RxDefaultBuffersSize[self->Index] :  g_UartController[self->Index].rxBufferSize;
 
     return TinyCLR_Result::Success;
 }
@@ -299,7 +299,7 @@ TinyCLR_Result LPC17_Uart_SetReadBufferSize(const TinyCLR_Uart_Provider* self, s
 }
 
 TinyCLR_Result LPC17_Uart_GetWriteBufferSize(const TinyCLR_Uart_Provider* self, size_t& size) {
-    size = g_UartController[self->Index].txBufferSize;
+    size = g_UartController[self->Index].txBufferSize == 0 ? g_LPC17_Uart_TxDefaultBuffersSize[self->Index] : g_UartController[self->Index].txBufferSize;
 
     return TinyCLR_Result::Success;
 }

--- a/Targets/LPC23xx_LPC24xx/LPC24_USART.cpp
+++ b/Targets/LPC23xx_LPC24xx/LPC24_USART.cpp
@@ -102,7 +102,7 @@ const TinyCLR_Api_Info* LPC24_Uart_GetApi() {
 }
 
 TinyCLR_Result LPC24_Uart_GetReadBufferSize(const TinyCLR_Uart_Provider* self, size_t& size) {
-    size = g_UartController[self->Index].rxBufferSize;
+    size = g_UartController[self->Index].rxBufferSize == 0 ? g_LPC24_Uart_RxDefaultBuffersSize[self->Index] :  g_UartController[self->Index].rxBufferSize;
 
     return TinyCLR_Result::Success;
 }
@@ -131,7 +131,7 @@ TinyCLR_Result LPC24_Uart_SetReadBufferSize(const TinyCLR_Uart_Provider* self, s
 }
 
 TinyCLR_Result LPC24_Uart_GetWriteBufferSize(const TinyCLR_Uart_Provider* self, size_t& size) {
-    size = g_UartController[self->Index].txBufferSize;
+    size = g_UartController[self->Index].txBufferSize == 0 ? g_LPC24_Uart_TxDefaultBuffersSize[self->Index] : g_UartController[self->Index].txBufferSize;
 
     return TinyCLR_Result::Success;
 }

--- a/Targets/STM32F4xx/STM32F4_UART.cpp
+++ b/Targets/STM32F4xx/STM32F4_UART.cpp
@@ -136,7 +136,7 @@ const TinyCLR_Api_Info* STM32F4_Uart_GetApi() {
 }
 
 TinyCLR_Result STM32F4_Uart_GetReadBufferSize(const TinyCLR_Uart_Provider* self, size_t& size) {
-    size = g_UartController[self->Index].rxBufferSize;
+    size = g_UartController[self->Index].rxBufferSize == 0 ? g_STM32F4_Uart_RxDefaultBuffersSize[self->Index] :  g_UartController[self->Index].rxBufferSize;
 
     return TinyCLR_Result::Success;
 }
@@ -165,7 +165,7 @@ TinyCLR_Result STM32F4_Uart_SetReadBufferSize(const TinyCLR_Uart_Provider* self,
 }
 
 TinyCLR_Result STM32F4_Uart_GetWriteBufferSize(const TinyCLR_Uart_Provider* self, size_t& size) {
-    size = g_UartController[self->Index].txBufferSize;
+    size = g_UartController[self->Index].txBufferSize == 0 ? g_STM32F4_Uart_TxDefaultBuffersSize[self->Index] : g_UartController[self->Index].txBufferSize;
 
     return TinyCLR_Result::Success;
 }


### PR DESCRIPTION
The value is set to default or other value in ActiveSetting. Reading these values before that it will be zero.