### PR TITLE
Return CAN default size if not set yet.

### DIFF
--- a/Targets/AT91SAM9X35/AT91_CAN.cpp
+++ b/Targets/AT91SAM9X35/AT91_CAN.cpp
@@ -1840,7 +1840,7 @@ TinyCLR_Result AT91_Can_GetSourceClock(const TinyCLR_Can_Provider* self, uint32_
 TinyCLR_Result AT91_Can_GetReadBufferSize(const TinyCLR_Can_Provider* self, size_t& size) {
     int32_t channel = self->Index;
 
-    size = canController[channel].can_rxBufferSize;
+    size = canController[channel].can_rxBufferSize == 0 ? g_AT91_Can_defaultBuffersSize[channel] : canController[channel].can_rxBufferSize;
 
     return TinyCLR_Result::Success;
 }
@@ -1859,9 +1859,7 @@ TinyCLR_Result AT91_Can_SetReadBufferSize(const TinyCLR_Can_Provider* self, size
 }
 
 TinyCLR_Result AT91_Can_GetWriteBufferSize(const TinyCLR_Can_Provider* self, size_t& size) {
-    int32_t channel = self->Index;
-
-    size = canController[channel].can_txBufferSize;
+    size = 1;
 
     return TinyCLR_Result::Success;
 }

--- a/Targets/LPC177x_LPC178x/LPC17_CAN.cpp
+++ b/Targets/LPC177x_LPC178x/LPC17_CAN.cpp
@@ -2789,7 +2789,7 @@ TinyCLR_Result LPC17_Can_GetSourceClock(const TinyCLR_Can_Provider* self, uint32
 TinyCLR_Result LPC17_Can_GetReadBufferSize(const TinyCLR_Can_Provider* self, size_t& size) {
     int32_t channel = self->Index;
 
-    size = canController[channel].can_rxBufferSize;
+    size = canController[channel].can_rxBufferSize == 0 ? g_LPC17_Can_defaultBuffersSize[channel] : canController[channel].can_rxBufferSize;
 
     return TinyCLR_Result::Success;
 }
@@ -2807,10 +2807,8 @@ TinyCLR_Result LPC17_Can_SetReadBufferSize(const TinyCLR_Can_Provider* self, siz
     }
 }
 
-TinyCLR_Result LPC17_Can_GetWriteBufferSize(const TinyCLR_Can_Provider* self, size_t& size) {
-    int32_t channel = self->Index;
-
-    size = canController[channel].can_txBufferSize;
+TinyCLR_Result LPC17_Can_GetWriteBufferSize(const TinyCLR_Can_Provider* self, size_t& size) {    
+    size = 1;
 
     return TinyCLR_Result::Success;
 }

--- a/Targets/LPC23xx_LPC24xx/LPC24_CAN.cpp
+++ b/Targets/LPC23xx_LPC24xx/LPC24_CAN.cpp
@@ -2793,7 +2793,7 @@ TinyCLR_Result LPC24_Can_GetSourceClock(const TinyCLR_Can_Provider* self, uint32
 TinyCLR_Result LPC24_Can_GetReadBufferSize(const TinyCLR_Can_Provider* self, size_t& size) {
     int32_t channel = self->Index;
 
-    size = canController[channel].can_rxBufferSize;
+    size = canController[channel].can_rxBufferSize == 0 ? g_LPC24_Can_defaultBuffersSize[channel] : canController[channel].can_rxBufferSize;
 
     return TinyCLR_Result::Success;
 }
@@ -2812,9 +2812,7 @@ TinyCLR_Result LPC24_Can_SetReadBufferSize(const TinyCLR_Can_Provider* self, siz
 }
 
 TinyCLR_Result LPC24_Can_GetWriteBufferSize(const TinyCLR_Can_Provider* self, size_t& size) {
-    int32_t channel = self->Index;
-
-    size = canController[channel].can_txBufferSize;
+    size = 1;
 
     return TinyCLR_Result::Success;
 }

--- a/Targets/STM32F4xx/STM32F4_CAN.cpp
+++ b/Targets/STM32F4xx/STM32F4_CAN.cpp
@@ -1070,7 +1070,7 @@ const TinyCLR_Api_Info* STM32F4_Can_GetApi() {
 TinyCLR_Result STM32F4_Can_GetReadBufferSize(const TinyCLR_Can_Provider* self, size_t& size) {
     int32_t channel = self->Index;
 
-    size = canController[channel].can_rxBufferSize;
+    size = canController[channel].can_rxBufferSize == 0 ? g_STM32F4_Can_defaultBuffersSize[channel] : canController[channel].can_rxBufferSize;
 
     return TinyCLR_Result::Success;
 }
@@ -1088,10 +1088,8 @@ TinyCLR_Result STM32F4_Can_SetReadBufferSize(const TinyCLR_Can_Provider* self, s
     }
 }
 
-TinyCLR_Result STM32F4_Can_GetWriteBufferSize(const TinyCLR_Can_Provider* self, size_t& size) {
-    int32_t channel = self->Index;
-
-    size = canController[channel].can_txBufferSize;
+TinyCLR_Result STM32F4_Can_GetWriteBufferSize(const TinyCLR_Can_Provider* self, size_t& size) {    
+    size = 1;
 
     return TinyCLR_Result::Success;
 }


### PR DESCRIPTION
CAN WriteSize is always 1. Set directly to 1 if read the write size