### PR TITLE
Prevent free memory once heap reset.

### DIFF
--- a/Targets/AT91SAM9Rx64/AT91_USART.cpp
+++ b/Targets/AT91SAM9Rx64/AT91_USART.cpp
@@ -689,10 +689,10 @@ TinyCLR_Result AT91_Uart_SetIsRequestToSendEnabled(const TinyCLR_Uart_Provider* 
 
 void AT91_Uart_Reset() {
     for (auto i = 0; i < TOTAL_UART_CONTROLLERS; i++) {
-        AT91_Uart_Release(uartProviders[i]);
-
         g_UartController[i].txBufferSize = 0;
         g_UartController[i].rxBufferSize = 0;
+
+        AT91_Uart_Release(uartProviders[i]);
 
         g_UartController[i].isOpened = false;
     }

--- a/Targets/AT91SAM9X35/AT91_CAN.cpp
+++ b/Targets/AT91SAM9X35/AT91_CAN.cpp
@@ -1871,6 +1871,8 @@ TinyCLR_Result AT91_Can_SetWriteBufferSize(const TinyCLR_Can_Provider* self, siz
 
 void AT91_Can_Reset() {
     for (int i = 0; i < TOTAL_CAN_CONTROLLERS; i++) {
+        canController[i].canRxMessagesFifo = nullptr;
+
         AT91_Can_Release(canProvider[i]);
 
         canController[i].isOpened = false;

--- a/Targets/AT91SAM9X35/AT91_USART.cpp
+++ b/Targets/AT91SAM9X35/AT91_USART.cpp
@@ -690,10 +690,10 @@ TinyCLR_Result AT91_Uart_SetIsRequestToSendEnabled(const TinyCLR_Uart_Provider* 
 
 void AT91_Uart_Reset() {
     for (auto i = 0; i < TOTAL_UART_CONTROLLERS; i++) {
-        AT91_Uart_Release(uartProviders[i]);
-
         g_UartController[i].txBufferSize = 0;
         g_UartController[i].rxBufferSize = 0;
+
+        AT91_Uart_Release(uartProviders[i]);
 
         g_UartController[i].isOpened = false;
     }

--- a/Targets/LPC177x_LPC178x/LPC17_CAN.cpp
+++ b/Targets/LPC177x_LPC178x/LPC17_CAN.cpp
@@ -2819,6 +2819,8 @@ TinyCLR_Result LPC17_Can_SetWriteBufferSize(const TinyCLR_Can_Provider* self, si
 
 void LPC17_Can_Reset() {
     for (int i = 0; i < TOTAL_CAN_CONTROLLERS; i++) {
+        canController[i].canRxMessagesFifo = nullptr;
+
         LPC17_Can_Release(canProvider[i]);
 
         canController[i].isOpened = false;

--- a/Targets/LPC177x_LPC178x/LPC17_USART.cpp
+++ b/Targets/LPC177x_LPC178x/LPC17_USART.cpp
@@ -971,10 +971,10 @@ TinyCLR_Result LPC17_Uart_SetIsRequestToSendEnabled(const TinyCLR_Uart_Provider*
 
 void LPC17_Uart_Reset() {
     for (auto i = 0; i < TOTAL_UART_CONTROLLERS; i++) {
-        LPC17_Uart_Release(uartProviders[i]);
-
         g_UartController[i].txBufferSize = 0;
         g_UartController[i].rxBufferSize = 0;
+
+        LPC17_Uart_Release(uartProviders[i]);
 
         g_UartController[i].isOpened = false;
     }

--- a/Targets/LPC23xx_LPC24xx/LPC24_CAN.cpp
+++ b/Targets/LPC23xx_LPC24xx/LPC24_CAN.cpp
@@ -2823,6 +2823,8 @@ TinyCLR_Result LPC24_Can_SetWriteBufferSize(const TinyCLR_Can_Provider* self, si
 
 void LPC24_Can_Reset() {
     for (int i = 0; i < TOTAL_CAN_CONTROLLERS; i++) {
+        canController[i].canRxMessagesFifo = nullptr;
+
         LPC24_Can_Release(canProvider[i]);
 
         canController[i].isOpened = false;

--- a/Targets/LPC23xx_LPC24xx/LPC24_USART.cpp
+++ b/Targets/LPC23xx_LPC24xx/LPC24_USART.cpp
@@ -788,10 +788,10 @@ TinyCLR_Result LPC24_Uart_SetIsRequestToSendEnabled(const TinyCLR_Uart_Provider*
 
 void LPC24_Uart_Reset() {
     for (auto i = 0; i < TOTAL_UART_CONTROLLERS; i++) {
-        LPC24_Uart_Release(uartProviders[i]);
-
         g_UartController[i].txBufferSize = 0;
         g_UartController[i].rxBufferSize = 0;
+
+        LPC24_Uart_Release(uartProviders[i]);
 
         g_UartController[i].isOpened = false;
     }

--- a/Targets/STM32F4xx/STM32F4_CAN.cpp
+++ b/Targets/STM32F4xx/STM32F4_CAN.cpp
@@ -1589,6 +1589,8 @@ TinyCLR_Result STM32F4_Can_GetSourceClock(const TinyCLR_Can_Provider* self, uint
 
 void STM32F4_Can_Reset() {
     for (int i = 0; i < TOTAL_CAN_CONTROLLERS; i++) {
+        canController[i].canRxMessagesFifo = nullptr;
+
         STM32F4_Can_Release(canProvider[i]);
 
         canController[i].isOpened = false;

--- a/Targets/STM32F4xx/STM32F4_UART.cpp
+++ b/Targets/STM32F4xx/STM32F4_UART.cpp
@@ -618,10 +618,10 @@ TinyCLR_Result STM32F4_Uart_Release(const TinyCLR_Uart_Provider* self) {
 
 void STM32F4_Uart_Reset() {
     for (auto i = 0; i < TOTAL_UART_CONTROLLERS; i++) {
-        STM32F4_Uart_Release(uartProviders[i]);
-
         g_UartController[i].txBufferSize = 0;
         g_UartController[i].rxBufferSize = 0;
+
+        STM32F4_Uart_Release(uartProviders[i]);
 
         g_UartController[i].isOpened = false;
     }

--- a/Targets/STM32F7xx/STM32F7_CAN.cpp
+++ b/Targets/STM32F7xx/STM32F7_CAN.cpp
@@ -1592,6 +1592,8 @@ TinyCLR_Result STM32F7_Can_GetSourceClock(const TinyCLR_Can_Provider* self, uint
 
 void STM32F7_Can_Reset() {
     for (int i = 0; i < TOTAL_CAN_CONTROLLERS; i++) {
+        canController[i].canRxMessagesFifo = nullptr;
+
         STM32F7_Can_Release(canProvider[i]);
 
         canController[i].isOpened = false;

--- a/Targets/STM32F7xx/STM32F7_UART.cpp
+++ b/Targets/STM32F7xx/STM32F7_UART.cpp
@@ -607,10 +607,10 @@ TinyCLR_Result STM32F7_Uart_Release(const TinyCLR_Uart_Provider* self) {
 
 void STM32F7_Uart_Reset() {
     for (auto i = 0; i < TOTAL_UART_CONTROLLERS; i++) {
-        STM32F7_Uart_Release(uartProviders[i]);
-
         g_UartController[i].txBufferSize = 0;
         g_UartController[i].rxBufferSize = 0;
+
+        STM32F7_Uart_Release(uartProviders[i]);
 
         g_UartController[i].isOpened = false;
     }


### PR DESCRIPTION
Fixed #249. No need to free memory once heap was reset.