### PR TITLE
Fixed #333. EMX and EMM this port was enable from BL1. Since Usbizi d…

### DIFF
--- a/Targets/LPC23xx_LPC24xx/LPC24_GPIO.cpp
+++ b/Targets/LPC23xx_LPC24xx/LPC24_GPIO.cpp
@@ -163,6 +163,8 @@ void LPC24_Gpio_EnsureTableInitialized() {
         gpioStates[i].controllerIndex = i;
         gpioStates[i].tableInitialized = true;
     }
+
+    SCS_BASE |= (1 << 0); // Enable for port 0 and 1
 }
 
 const TinyCLR_Api_Info* LPC24_Gpio_GetRequiredApi() {
@@ -501,8 +503,6 @@ uint32_t LPC24_Gpio_GetPinCount(const TinyCLR_Gpio_Controller* self) {
 }
 
 void LPC24_Gpio_Reset() {
-    SCS_BASE |= (1 << 0); // Enable for port 0 and 1
-
     for (auto c = 0; c < TOTAL_GPIO_CONTROLLERS; c++) {
         for (auto pin = 0; pin < LPC24_Gpio_GetPinCount(&gpioControllers[c]); pin++) {
             auto& p = gpioPins[pin];


### PR DESCRIPTION
…oesn't have BL1, this port need to be enable asap because they will be used before gpio reset.