### PR TITLE
Add #define MEMORY_PROFILE_FACTOR_LEVEL for 3 basic devices

### DIFF
--- a/Devices/FEZCLR/Device.h
+++ b/Devices/FEZCLR/Device.h
@@ -108,3 +108,5 @@
 #define STM32F4_USB_DP_PINS { { PIN(A, 12), AF(10) } }
 #define STM32F4_USB_VB_PINS { { PIN(A,  9), AF(10) } }
 #define STM32F4_USB_ID_PINS { { PIN(A, 10), AF(10) } }
+
+#define MEMORY_PROFILE_FACTOR_LEVEL 3

--- a/Devices/G80/Device.h
+++ b/Devices/G80/Device.h
@@ -135,3 +135,5 @@
 #define STM32F4_USB_DP_PINS { { PIN(A, 12), AF(10) } }
 #define STM32F4_USB_VB_PINS { { PIN(A,  9), AF(10) } }
 #define STM32F4_USB_ID_PINS { { PIN(A, 10), AF(10) } }
+
+#define MEMORY_PROFILE_FACTOR_LEVEL 7

--- a/Devices/UC5550/Device.h
+++ b/Devices/UC5550/Device.h
@@ -146,3 +146,5 @@
 #define STM32F7_DISPLAY_CONTROLLER_PINS { { PIN(I, 12), AF(14) }, { PIN(I, 13), AF(14) }, { PIN(I, 14), AF(14) }, { PIN(J, 2), AF(14) },{ PIN(J, 3), AF(14) },{ PIN(J, 4), AF(14) },{ PIN(J, 5), AF(14) },{ PIN(J, 6), AF(14) },{ PIN(J, 9), AF(14) },{ PIN(J, 10), AF(14) },{ PIN(J, 11), AF(14) },{ PIN(J, 15), AF(14) }, { PIN(K, 0), AF(14) },{ PIN(K, 1), AF(14) },{ PIN(K, 2), AF(14) },{ PIN(K, 3), AF(14) },{ PIN(K, 4), AF(14) },{ PIN(K, 5), AF(14) },{ PIN(K, 6), AF(14) } }
 #define STM32F7_DISPLAY_BACKLIGHT_PIN  { PIN(D, 7), AF(0) }
 #define STM32F7_DISPLAY_ENABLE_PIN  { PIN(K, 7), AF(14) }
+
+#define MEMORY_PROFILE_FACTOR_LEVEL 9


### PR DESCRIPTION
Due to ghi-electronics/TinyCLR-Core/#335
