### PR TITLE
Fixed ghi-electronics/TinyCLR-Devices#256.

### DIFF
--- a/Devices/UC2550/Scatterfile.gcc.ldf
+++ b/Devices/UC2550/Scatterfile.gcc.ldf
@@ -72,12 +72,12 @@ SECTIONS
         * (SectionForHeapBegin)
     }>IRAM
 
-    ER_HEAP_END 0x2003F000 - 0x08 :
+    ER_HEAP_END 0x2003E000 - 0x08 :
     {
         * (SectionForHeapEnd)
     }>IRAM
 
-    ER_RLP_BEGIN 0x2003F000 :
+    ER_RLP_BEGIN 0x2003E000 :
     {
         * (SectionForRlpBegin)
     }>IRAM


### PR DESCRIPTION
Only increased uc2550 from 4KB to 8KB because this device has more memory than G80.