### PR TITLE
#256 improve gpio interrupt

### DIFF
--- a/Targets/AT91SAM9Rx64/AT91_GPIO.cpp
+++ b/Targets/AT91SAM9Rx64/AT91_GPIO.cpp
@@ -140,9 +140,9 @@ void AT91_Gpio_InterruptHandler(void* param) {
                 bitIndex++;
             }
 
-            bool executeIsr = true;
+            bool executeIsr = false;
 
-            GpioInterruptState* interruptState = &gpioInterruptState[bitIndex + port * 32];;
+            GpioInterruptState* interruptState = &gpioInterruptState[bitIndex + port * 32];
 
             AT91_Gpio_Read(interruptState->controller, interruptState->pin, interruptState->currentValue); // read value as soon as possible
 
@@ -153,11 +153,10 @@ void AT91_Gpio_InterruptHandler(void* param) {
             if (interruptState->handler && ((expectedEdgeInterger & currentEdgeInterger) || (expectedEdgeInterger == 0))) {
                 if (interruptState->debounce) {
                     if ((AT91_Time_GetTimeForProcessorTicks(nullptr, AT91_Time_GetCurrentProcessorTicks(nullptr)) - interruptState->lastDebounceTicks) >= gpioDebounceInTicks[interruptState->pin]) {
-                        interruptState->lastDebounceTicks = AT91_Time_GetTimeForProcessorTicks(nullptr, AT91_Time_GetCurrentProcessorTicks(nullptr));
+                        executeIsr = true;
                     }
-                    else {
-                        executeIsr = false;
-                    }
+
+                    interruptState->lastDebounceTicks = AT91_Time_GetTimeForProcessorTicks(nullptr, AT91_Time_GetCurrentProcessorTicks(nullptr));
                 }
 
                 if (executeIsr)

--- a/Targets/AT91SAM9Rx64/AT91_GPIO.cpp
+++ b/Targets/AT91SAM9Rx64/AT91_GPIO.cpp
@@ -338,7 +338,7 @@ bool AT91_Gpio_ConfigurePin(int32_t pin, AT91_Gpio_Direction pinDir, AT91_Gpio_P
 
 
 bool AT91_Gpio_ConfigurePin(int32_t pin, AT91_Gpio_Direction pinDir, AT91_Gpio_PeripheralSelection peripheralSelection, AT91_Gpio_ResistorMode resistorMode) {
-    return AT91_Gpio_ConfigurePin(pin, pinDir, peripheralSelection, resistorMode, AT91_Gpio_MultiDriver::Disable, AT91_Gpio_Filter::Enable, AT91_Gpio_FilterSlowClock::Disable, AT91_Gpio_Schmitt::Disable, AT91_Gpio_DriveSpeed::Reserved);
+    return AT91_Gpio_ConfigurePin(pin, pinDir, peripheralSelection, resistorMode, AT91_Gpio_MultiDriver::Disable, AT91_Gpio_Filter::Enable, AT91_Gpio_FilterSlowClock::Enable, AT91_Gpio_Schmitt::Disable, AT91_Gpio_DriveSpeed::Reserved);
 }
 
 void AT91_Gpio_EnableOutputPin(int32_t pin, bool initialState) {

--- a/Targets/AT91SAM9X35/AT91_GPIO.cpp
+++ b/Targets/AT91SAM9X35/AT91_GPIO.cpp
@@ -356,7 +356,7 @@ bool AT91_Gpio_ConfigurePin(int32_t pin, AT91_Gpio_Direction pinDir, AT91_Gpio_P
 
 
 bool AT91_Gpio_ConfigurePin(int32_t pin, AT91_Gpio_Direction pinDir, AT91_Gpio_PeripheralSelection peripheralSelection, AT91_Gpio_ResistorMode resistorMode) {
-    return AT91_Gpio_ConfigurePin(pin, pinDir, peripheralSelection, resistorMode, AT91_Gpio_MultiDriver::Disable, AT91_Gpio_Filter::Enable, AT91_Gpio_FilterSlowClock::Disable, AT91_Gpio_Schmitt::Disable, AT91_Gpio_DriveSpeed::Reserved);
+    return AT91_Gpio_ConfigurePin(pin, pinDir, peripheralSelection, resistorMode, AT91_Gpio_MultiDriver::Disable, AT91_Gpio_Filter::Enable, AT91_Gpio_FilterSlowClock::Enable, AT91_Gpio_Schmitt::Disable, AT91_Gpio_DriveSpeed::Reserved);
 }
 
 void AT91_Gpio_EnableOutputPin(int32_t pin, bool initialState) {

--- a/Targets/AT91SAM9X35/AT91_GPIO.cpp
+++ b/Targets/AT91SAM9X35/AT91_GPIO.cpp
@@ -142,9 +142,9 @@ void AT91_Gpio_InterruptHandler(void* param) {
                 bitIndex++;
             }
 
-            bool executeIsr = true;
+            bool executeIsr = false;
 
-            GpioInterruptState* interruptState = &gpioInterruptState[bitIndex + port * 32];;
+            GpioInterruptState* interruptState = &gpioInterruptState[bitIndex + port * 32];
 
             AT91_Gpio_Read(interruptState->controller, interruptState->pin, interruptState->currentValue); // read value as soon as possible
 
@@ -155,11 +155,10 @@ void AT91_Gpio_InterruptHandler(void* param) {
             if (interruptState->handler && ((expectedEdgeInterger & currentEdgeInterger) || (expectedEdgeInterger == 0))) {
                 if (interruptState->debounce) {
                     if ((AT91_Time_GetTimeForProcessorTicks(nullptr, AT91_Time_GetCurrentProcessorTicks(nullptr)) - interruptState->lastDebounceTicks) >= gpioDebounceInTicks[interruptState->pin]) {
-                        interruptState->lastDebounceTicks = AT91_Time_GetTimeForProcessorTicks(nullptr, AT91_Time_GetCurrentProcessorTicks(nullptr));
+                        executeIsr = true;
                     }
-                    else {
-                        executeIsr = false;
-                    }
+
+                    interruptState->lastDebounceTicks = AT91_Time_GetTimeForProcessorTicks(nullptr, AT91_Time_GetCurrentProcessorTicks(nullptr));
                 }
 
                 if (executeIsr)

--- a/Targets/LPC177x_LPC178x/LPC17_GPIO.cpp
+++ b/Targets/LPC177x_LPC178x/LPC17_GPIO.cpp
@@ -148,7 +148,7 @@ void LPC17_Gpio_InterruptHandler(void* param) {
 
     uint32_t* GPIO_INT_Overall_IO_Status_Register = GPIO_INT_Overall_IO_Status;
 
-    bool executeIsr = true;
+    bool executeIsr = false;
 
     for (auto port = 0; port <= 2; port += 2) { // Only port 0 and port 2 support interrupts
         auto status_mask_register = 1 << port;
@@ -174,12 +174,11 @@ void LPC17_Gpio_InterruptHandler(void* param) {
 
             if (interruptState->handler && ((expectedEdgeInterger & currentEdgeInterger) || (expectedEdgeInterger == 0))) {
                 if (interruptState->debounce) {
-                    if ((LPC17_Time_GetTimeForProcessorTicks(nullptr, LPC17_Time_GetCurrentProcessorTicks(nullptr)) - interruptState->lastDebounceTicks) >= gpioDebounceInTicks[interruptState->pin]) {
-                        interruptState->lastDebounceTicks = LPC17_Time_GetTimeForProcessorTicks(nullptr, LPC17_Time_GetCurrentProcessorTicks(nullptr));
+                    if ((LPC17_Time_GetTimeForProcessorTicks(nullptr, LPC17_Time_GetCurrentProcessorTicks(nullptr)) - interruptState->lastDebounceTicks) >= gpioDebounceInTicks[interruptState->pin]) {                        
+                        executeIsr = true;
                     }
-                    else {
-                        executeIsr = false;
-                    }
+
+                    interruptState->lastDebounceTicks = LPC17_Time_GetTimeForProcessorTicks(nullptr, LPC17_Time_GetCurrentProcessorTicks(nullptr));
                 }
 
                 if (executeIsr)

--- a/Targets/LPC23xx_LPC24xx/LPC24_GPIO.cpp
+++ b/Targets/LPC23xx_LPC24xx/LPC24_GPIO.cpp
@@ -197,7 +197,7 @@ void LPC24_Gpio_InterruptHandler(void* param) {
 
     DISABLE_INTERRUPTS_SCOPED(irq);
 
-    bool executeIsr = true;
+    bool executeIsr = false;
 
     for (auto port = 0; port <= 2; port += 2) { // Only port 0 and port 2 support interrupts
         auto status_mask_register = 1 << port;
@@ -220,11 +220,10 @@ void LPC24_Gpio_InterruptHandler(void* param) {
             if (interruptState->handler && ((expectedEdgeInterger & currentEdgeInterger) || (expectedEdgeInterger == 0))) {
                 if (interruptState->debounce) {
                     if ((LPC24_Time_GetTimeForProcessorTicks(nullptr, LPC24_Time_GetCurrentProcessorTicks(nullptr)) - interruptState->lastDebounceTicks) >= gpioDebounceInTicks[interruptState->pin]) {
-                        interruptState->lastDebounceTicks = LPC24_Time_GetTimeForProcessorTicks(nullptr, LPC24_Time_GetCurrentProcessorTicks(nullptr));
-                    }
-                    else {
                         executeIsr = false;
                     }
+
+                    interruptState->lastDebounceTicks = LPC24_Time_GetTimeForProcessorTicks(nullptr, LPC24_Time_GetCurrentProcessorTicks(nullptr));
                 }
 
                 if (executeIsr)

--- a/Targets/STM32F4xx/STM32F4_GPIO.cpp
+++ b/Targets/STM32F4xx/STM32F4_GPIO.cpp
@@ -127,7 +127,7 @@ void STM32F4_Gpio_ISR(int num)  // 0 <= num <= 15
 
     DISABLE_INTERRUPTS_SCOPED(irq);
 
-    bool executeIsr = true;
+    bool executeIsr = false;
 
     GpioInterruptState* interruptState = &gpioInterruptState[num];
 
@@ -144,11 +144,10 @@ void STM32F4_Gpio_ISR(int num)  // 0 <= num <= 15
     if (interruptState->handler && ((expectedEdgeInterger & currentEdgeInterger) || (expectedEdgeInterger == 0))) {
         if (interruptState->debounce) {   // debounce enabled
             if ((STM32F4_Time_GetTimeForProcessorTicks(nullptr, STM32F4_Time_GetCurrentProcessorTicks(nullptr)) - interruptState->lastDebounceTicks) >= gpioDebounceInTicks[interruptState->pin]) {
-                interruptState->lastDebounceTicks = STM32F4_Time_GetTimeForProcessorTicks(nullptr, STM32F4_Time_GetCurrentProcessorTicks(nullptr));
+                executeIsr = true;
             }
-            else {
-                executeIsr = false;
-            }
+
+            interruptState->lastDebounceTicks = STM32F4_Time_GetTimeForProcessorTicks(nullptr, STM32F4_Time_GetCurrentProcessorTicks(nullptr));
         }
 
         if (executeIsr)

--- a/Targets/STM32F7xx/STM32F7_GPIO.cpp
+++ b/Targets/STM32F7xx/STM32F7_GPIO.cpp
@@ -128,7 +128,7 @@ void STM32F7_Gpio_ISR(int num)  // 0 <= num <= 15
 
     DISABLE_INTERRUPTS_SCOPED(irq);
 
-    bool executeIsr = true;
+    bool executeIsr = false;
 
     GpioInterruptState* interruptState = &gpioInterruptState[num];
 
@@ -145,12 +145,10 @@ void STM32F7_Gpio_ISR(int num)  // 0 <= num <= 15
     if (interruptState->handler && ((expectedEdgeInterger & currentEdgeInterger) || (expectedEdgeInterger == 0))) {
         if (interruptState->debounce) {   // debounce enabled
             if ((STM32F7_Time_GetTimeForProcessorTicks(nullptr, STM32F7_Time_GetCurrentProcessorTicks(nullptr)) - interruptState->lastDebounceTicks) >= gpioDebounceInTicks[interruptState->pin]) {
-                interruptState->lastDebounceTicks = STM32F7_Time_GetTimeForProcessorTicks(nullptr, STM32F7_Time_GetCurrentProcessorTicks(nullptr));
-            }
-            else {
-                executeIsr = false;
+                executeIsr = true;
             }
 
+            interruptState->lastDebounceTicks = STM32F7_Time_GetTimeForProcessorTicks(nullptr, STM32F7_Time_GetCurrentProcessorTicks(nullptr));
         }
 
         if (executeIsr)


### PR DESCRIPTION
Fixed ghi-electronics/TinyCLR-Libraries#265.

The state of pin should be read from event  GpioPinValueChangedEventArgs e

Reading by pin.Read() in event function has some delay which may inaccurate.