### PR TITLE
Fixed #460.

### DIFF
--- a/Targets/AT91SAM9X35/AT91_RTC.cpp
+++ b/Targets/AT91SAM9X35/AT91_RTC.cpp
@@ -122,7 +122,7 @@ TinyCLR_Result AT91_Rtc_IsValid(const TinyCLR_Rtc_Controller* self, bool& value)
 
     value = (AT91_Rtc_GetTime(self, rtcNow) == TinyCLR_Result::Success);
 
-    if (rtcNow.Second >= 60 || rtcNow.Minute >= 60 || rtcNow.Hour >= 24 || rtcNow.DayOfMonth >= 32 || rtcNow.Month >= 13 || rtcNow.Year <= 1979 || rtcNow.DayOfWeek == 0)
+    if (rtcNow.Second >= 60 || rtcNow.Minute >= 60 || rtcNow.Hour >= 24 || rtcNow.DayOfMonth >= 32 || rtcNow.Month >= 13 || rtcNow.DayOfWeek >= 8)
         value = false;
 
     return TinyCLR_Result::Success;
@@ -134,14 +134,8 @@ TinyCLR_Result AT91_Rtc_GetTime(const TinyCLR_Rtc_Controller* self, TinyCLR_Rtc_
     uint32_t fullYear = 0;
     uint32_t hundredYear = 0;
 
-    if (RTC_VER > 0) {
-        value.Year = 1977;
-        value.Month = 1;
-        value.DayOfMonth = 1;
-        value.Hour = 1;
-        value.Minute = 1;
-        value.Second = 1;
-        value.Millisecond = 1;
+    if (RTC_VER > 0) { // Valid Entry Register, detect any incorrect value this register will be not 0.
+        return TinyCLR_Result::InvalidOperation;
     }
     else {
         if ((calenderRegister & 0x7F) == 0x19)
@@ -153,6 +147,7 @@ TinyCLR_Result AT91_Rtc_GetTime(const TinyCLR_Rtc_Controller* self, TinyCLR_Rtc_
         value.Year = (uint32_t)(fullYear + hundredYear);
         value.Month = (uint32_t)AT91_Rtc_BinaryCodedDecimalCombine((((calenderRegister & (0x1F << 16)) >> 16) >> 4), (((calenderRegister & (0x1F << 16)) >> 16) & 0xF));
         value.DayOfMonth = (uint32_t)AT91_Rtc_BinaryCodedDecimalCombine((((calenderRegister & (0x3F << 24)) >> 24) >> 4), (((calenderRegister & (0x3F << 24)) >> 24) & 0xF));
+        value.DayOfWeek = (uint32_t)AT91_Rtc_BinaryCodedDecimalCombine((((calenderRegister & (0x07 << 21)) >> 21) >> 4), (((calenderRegister & (0x07 << 21)) >> 21) & 0xF));
         value.Hour = AT91_Rtc_BinaryCodedDecimalCombine((((timeRegister & (0x3F << 16)) >> 16) >> 4), (((timeRegister & (0x3F << 16)) >> 16) & 0xF));
 
         if (((timeRegister & 0x400000) >> 22) == AT91_RTC_TIMR_PM)
@@ -176,14 +171,14 @@ TinyCLR_Result AT91_Rtc_SetTime(const TinyCLR_Rtc_Controller* self, TinyCLR_Rtc_
     uint32_t ones = 0;
     uint32_t timeout = 0;
 
-    if (RTC_VER > 0) {
+    if (RTC_VER > 0) { // Valid Entry Register, detect any incorrect value this register will be not 0.
         return TinyCLR_Result::InvalidOperation;
     }
 
     if ((value.Year < 1900) || (value.Year > 2099) ||
         (value.Month < 1) || (value.Month > 12) ||
         (value.DayOfMonth < 1) || (value.DayOfMonth > 31)) {
-        TinyCLR_Result::ArgumentInvalid;
+        return TinyCLR_Result::ArgumentInvalid;
     }
 
     RTC_CR = 0x2;

--- a/Targets/LPC177x_LPC178x/LPC17_RTC.cpp
+++ b/Targets/LPC177x_LPC178x/LPC17_RTC.cpp
@@ -65,7 +65,7 @@ TinyCLR_Result LPC17_Rtc_IsValid(const TinyCLR_Rtc_Controller* self, bool& value
 
     value = (LPC17_Rtc_GetTime(self, rtcNow) == TinyCLR_Result::Success);
 
-    if (rtcNow.Second >= 60 || rtcNow.Minute >= 60 || rtcNow.Hour >= 24 || rtcNow.DayOfMonth >= 32 || rtcNow.Month >= 13 || rtcNow.Year <= 1979 || rtcNow.DayOfWeek == 0)
+    if (rtcNow.Second >= 60 || rtcNow.Minute >= 60 || rtcNow.Hour >= 24 || rtcNow.DayOfMonth >= 32 || rtcNow.Month >= 13 || rtcNow.DayOfWeek >= 8)
         value = false;
 
     return TinyCLR_Result::Success;
@@ -73,14 +73,13 @@ TinyCLR_Result LPC17_Rtc_IsValid(const TinyCLR_Rtc_Controller* self, bool& value
 
 TinyCLR_Result LPC17_Rtc_GetTime(const TinyCLR_Rtc_Controller* self, TinyCLR_Rtc_DateTime& value) {
     if (LPC_RTC->CCR != 1) {
-        TinyCLR_Result::InvalidOperation;
+        return TinyCLR_Result::InvalidOperation;
     }
 
     value.Hour = LPC_RTC->HOUR;
     value.Minute = LPC_RTC->MIN;
     value.Second = LPC_RTC->SEC;
     value.Millisecond = 0;
-
 
     value.Year = LPC_RTC->YEAR;
     value.Month = LPC_RTC->MONTH;
@@ -92,7 +91,7 @@ TinyCLR_Result LPC17_Rtc_GetTime(const TinyCLR_Rtc_Controller* self, TinyCLR_Rtc
 
 TinyCLR_Result LPC17_Rtc_SetTime(const TinyCLR_Rtc_Controller* self, TinyCLR_Rtc_DateTime value) {
     if (LPC_RTC->CCR != 1) {
-        TinyCLR_Result::InvalidOperation;
+        return TinyCLR_Result::InvalidOperation;
     }
 
     LPC_RTC->YEAR = value.Year;

--- a/Targets/LPC23xx_LPC24xx/LPC24_RTC.cpp
+++ b/Targets/LPC23xx_LPC24xx/LPC24_RTC.cpp
@@ -83,7 +83,7 @@ TinyCLR_Result LPC24_Rtc_IsValid(const TinyCLR_Rtc_Controller* self, bool& value
 
     value = (LPC24_Rtc_GetTime(self, rtcNow) == TinyCLR_Result::Success);
 
-    if (rtcNow.Second >= 60 || rtcNow.Minute >= 60 || rtcNow.Hour >= 24 || rtcNow.DayOfMonth >= 32 || rtcNow.Month >= 13 || rtcNow.Year <= 1979 || rtcNow.DayOfWeek == 0)
+    if (rtcNow.Second >= 60 || rtcNow.Minute >= 60 || rtcNow.Hour >= 24 || rtcNow.DayOfMonth >= 32 || rtcNow.Month >= 13 || rtcNow.DayOfWeek >= 8)
         value = false;
 
     return TinyCLR_Result::Success;
@@ -93,7 +93,7 @@ TinyCLR_Result LPC24_Rtc_GetTime(const TinyCLR_Rtc_Controller* self, TinyCLR_Rtc
     uint32_t* rtc_ccr_reg = reinterpret_cast<uint32_t*>(RTC_CCR);
 
     if (*rtc_ccr_reg != (1 | (1 << 4))) {
-        TinyCLR_Result::InvalidOperation;
+        return TinyCLR_Result::InvalidOperation;
     }
 
     value.Hour = *(reinterpret_cast<uint32_t*>(RTC_HOUR));
@@ -126,13 +126,13 @@ TinyCLR_Result LPC24_Rtc_GetTime(const TinyCLR_Rtc_Controller* self, TinyCLR_Rtc
 TinyCLR_Result LPC24_Rtc_SetTime(const TinyCLR_Rtc_Controller* self, TinyCLR_Rtc_DateTime value) {
     uint32_t* rtc_ccr_reg = reinterpret_cast<uint32_t*>(RTC_CCR);
     if (*rtc_ccr_reg != (1 | (1 << 4))) {
-        TinyCLR_Result::InvalidOperation;
+        return TinyCLR_Result::InvalidOperation;
     }
 
     if ((value.Year < 1601) || (value.Year > 3000) ||
         (value.Month < 1) || (value.Month > 12) ||
         (value.DayOfMonth < 1) || (value.DayOfMonth > 31)) {
-        TinyCLR_Result::ArgumentInvalid;
+        return TinyCLR_Result::ArgumentInvalid;
     }
 
     *(reinterpret_cast<uint32_t*>(RTC_YEAR)) = value.Year;

--- a/Targets/STM32F4xx/STM32F4_RTC.cpp
+++ b/Targets/STM32F4xx/STM32F4_RTC.cpp
@@ -231,6 +231,14 @@ TinyCLR_Result STM32F4_Rtc_Initialize() {
     return TinyCLR_Result::Success;
 }
 
+void STM32F4_Rtc_WriteBackupRegister() {
+    *(reinterpret_cast<uint32_t *>(RTC_BASE + 0x50)) = (uint32_t)0x32F2;
+}
+
+uint32_t STM32F4_Rtc_ReadBackupRegister() {
+    return *(reinterpret_cast<uint32_t *>(RTC_BASE + 0x50));
+}
+
 TinyCLR_Result STM32F4_Rtc_Acquire(const TinyCLR_Rtc_Controller* self) {
     if (STM32F4_Rtc_Configuration() != TinyCLR_Result::Success)
         return TinyCLR_Result::InvalidOperation;
@@ -250,8 +258,9 @@ TinyCLR_Result STM32F4_Rtc_IsValid(const TinyCLR_Rtc_Controller* self, bool& val
 
     value = (STM32F4_Rtc_GetTime(self, rtcNow) == TinyCLR_Result::Success);
 
-    if (rtcNow.Second >= 60 || rtcNow.Minute >= 60 || rtcNow.Hour >= 24 || rtcNow.DayOfMonth >= 32 || rtcNow.Month >= 13 || rtcNow.Year <= 1979 || rtcNow.DayOfWeek == 0)
+    if (rtcNow.Second >= 60 || rtcNow.Minute >= 60 || rtcNow.Hour >= 24 || rtcNow.DayOfMonth >= 32 || rtcNow.Month >= 13 || rtcNow.DayOfWeek >= 8)
         value = false;
+
 
     return TinyCLR_Result::Success;
 }
@@ -259,6 +268,10 @@ TinyCLR_Result STM32F4_Rtc_IsValid(const TinyCLR_Rtc_Controller* self, bool& val
 TinyCLR_Result STM32F4_Rtc_GetTime(const TinyCLR_Rtc_Controller* self, TinyCLR_Rtc_DateTime& value) {
     uint32_t  time;
     uint32_t  date;
+
+    if (STM32F4_Rtc_ReadBackupRegister() != 0x32F2) {
+        return TinyCLR_Result::InvalidOperation;
+    }
 
     /* Get the RTC_TR register */
     time = RTC->TR & RTC_TR_RESERVED_MASK;
@@ -314,6 +327,12 @@ TinyCLR_Result STM32F4_Rtc_SetTime(const TinyCLR_Rtc_Controller* self, TinyCLR_R
 
     /* Enable the write protection for RTC registers */
     STM32F4_Rtc_SetWriteProtection(true);
+
+    STM32F4_Rtc_WriteBackupRegister();
+
+    if (STM32F4_Rtc_ReadBackupRegister() != 0x32F2) { // Ensure data is written
+        return TinyCLR_Result::InvalidOperation;
+    }
 
     return TinyCLR_Result::Success;
 }


### PR DESCRIPTION
- We don't check year because the year is different on each devices if RTC is not initialized
- All devices, we return Invalid if detected any wrong or RTC is not set yet. How to deal with this error depends on managed side. 