### PR TITLE
Fixed #487. Use native memcpy to flush the lcd buffer.

### DIFF
--- a/Targets/AT91SAM9Rx64/AT91_Display.cpp
+++ b/Targets/AT91SAM9Rx64/AT91_Display.cpp
@@ -465,6 +465,8 @@ bool m_AT91_DisplayEnable = false;
 uint32_t displayInitializeCount = 0;
 
 uint16_t* m_AT91_Display_VituralRam = nullptr;
+uint32_t* m_AT91_Display_buffer = nullptr;
+
 size_t m_AT91_DisplayBufferSize = 0;
 
 uint8_t m_AT91_Display_TextBuffer[LCD_MAX_COLUMN][LCD_MAX_ROW];
@@ -804,11 +806,11 @@ void AT91_Display_Clear() {
 bool AT91_Display_SetPinConfiguration(int32_t controllerIndex, bool enable) {
     if (enable) {
         // Open multi lcd pins
-        if (!AT91_GpioInternal_OpenMultiPins(displayPins[controllerIndex], 20)) {
+        if (!AT91_GpioInternal_OpenMultiPins(displayPins[controllerIndex], SIZEOF_ARRAY(displayPins[controllerIndex]))) {
             return false;
         }
 
-        for (uint32_t pin = 0; pin < SIZEOF_ARRAY(displayPins); pin++) {
+        for (uint32_t pin = 0; pin < SIZEOF_ARRAY(displayPins[controllerIndex]); pin++) {
             AT91_GpioInternal_ConfigurePin(displayPins[controllerIndex][pin].number, AT91_Gpio_Direction::Input, displayPins[controllerIndex][pin].peripheralSelection, AT91_Gpio_ResistorMode::Inactive);
         }
 
@@ -869,32 +871,6 @@ int32_t AT91_Display_GetOrientation() {
     return m_AT91_Display_CurrentRotation;
 }
 
-void  AT91_Display_MemCopy(void *dest, void *src, int32_t size) {
-    const int32_t MEMCOPY_BYTES_ALIGNED = 8;
-
-    uint64_t *from64 = (uint64_t *)src;
-    uint64_t *to64 = (uint64_t *)dest;
-
-    int32_t block = size / MEMCOPY_BYTES_ALIGNED;
-    int32_t remainder = size % MEMCOPY_BYTES_ALIGNED;
-
-    while (block > 0) {
-        *to64++ = *from64++;
-        block--;
-    }
-
-    if (remainder > 0) {
-        uint8_t *from8 = (uint8_t *)from64;
-        uint8_t *to8 = (uint8_t *)to64;
-
-        while (remainder > 0) {
-            *to8++ = *from8++;
-
-            remainder--;
-        }
-    }
-}
-
 void AT91_Display_BitBltEx(int32_t x, int32_t y, int32_t width, int32_t height, uint32_t data[]) {
 
     int32_t xTo, yTo, xFrom, yFrom;
@@ -916,11 +892,11 @@ void AT91_Display_BitBltEx(int32_t x, int32_t y, int32_t width, int32_t height, 
 
         if (xOffset == 0 && yOffset == 0 &&
             width == screenWidth && height == screenHeight) {
-            AT91_Display_MemCopy(to, from, (screenWidth*screenHeight * 2));
+            memcpy(to, from, (screenWidth*screenHeight * 2));
         }
         else {
             for (yTo = yOffset; yTo < (yOffset + height); yTo++) {
-                AT91_Display_MemCopy((void*)(to + yTo * screenWidth + xOffset), (void*)(from), (width * 2));
+                memcpy((void*)(to + yTo * screenWidth + xOffset), (void*)(from), (width * 2));
                 from += width;
             }
         }
@@ -1051,12 +1027,12 @@ TinyCLR_Result AT91_Display_Release(const TinyCLR_Display_Controller* self) {
 
         m_AT91_DisplayEnable = false;
 
-        if (m_AT91_Display_VituralRam != nullptr) {
+        if (m_AT91_Display_buffer != nullptr) {
             auto memoryProvider = (const TinyCLR_Memory_Manager*)apiManager->FindDefault(apiManager, TinyCLR_Api_Type::MemoryManager);
 
-            memoryProvider->Free(memoryProvider, m_AT91_Display_VituralRam);
+            memoryProvider->Free(memoryProvider, m_AT91_Display_buffer);
 
-            m_AT91_Display_VituralRam = nullptr;
+            m_AT91_Display_buffer = nullptr;
         }
     }
 
@@ -1120,18 +1096,21 @@ TinyCLR_Result AT91_Display_SetConfiguration(const TinyCLR_Display_Controller* s
 
         auto memoryProvider = (const TinyCLR_Memory_Manager*)apiManager->FindDefault(apiManager, TinyCLR_Api_Type::MemoryManager);
 
-        if (m_AT91_Display_VituralRam != nullptr) {
-            memoryProvider->Free(memoryProvider, m_AT91_Display_VituralRam);
+        if (m_AT91_Display_buffer != nullptr) {
+            memoryProvider->Free(memoryProvider, m_AT91_Display_buffer);
 
-            m_AT91_Display_VituralRam = nullptr;
+            m_AT91_Display_buffer = nullptr;
         }
 
-        m_AT91_Display_VituralRam = (uint16_t*)((uint8_t*)memoryProvider->Allocate(memoryProvider, m_AT91_DisplayBufferSize));
+        m_AT91_Display_buffer = (uint32_t*)memoryProvider->Allocate(memoryProvider, m_AT91_DisplayBufferSize + 8);
 
-        if (m_AT91_Display_VituralRam == nullptr) {
+        if (m_AT91_Display_buffer == nullptr) {
             return TinyCLR_Result::OutOfMemory;
         }
 
+        m_AT91_Display_VituralRam = (uint16_t*)((((uint32_t)m_AT91_Display_buffer) + (7)) & (~((uint32_t)(7))));
+
+        // Set displayEnablePin following m_AT91_DisplayOutputEnableIsFixed
         if (displayEnablePin.number != PIN_NONE) {
             if (m_AT91_DisplayOutputEnableIsFixed) {
                 AT91_GpioInternal_EnableOutputPin(displayEnablePin.number, m_AT91_DisplayOutputEnablePolarity);
@@ -1247,7 +1226,9 @@ void AT91_Display_AddApi(const TinyCLR_Api_Manager* apiManager) {
         apiManager->Add(apiManager, &displayApi[i]);
     }
 
-    m_AT91_Display_VituralRam = nullptr;
+    displayInitializeCount = 0;
+    m_AT91_Display_buffer = nullptr;
+    m_AT91_DisplayEnable = false;
 
     apiManager->SetDefaultName(apiManager, TinyCLR_Api_Type::DisplayController, displayApi[0].Name);
 }
@@ -1260,5 +1241,6 @@ void AT91_Display_Reset() {
 
     m_AT91_DisplayEnable = false;
     displayInitializeCount = 0;
+    m_AT91_Display_buffer = nullptr;
 }
 #endif // INCLUDE_DISPLAY

--- a/Targets/LPC177x_LPC178x/LPC17_Display.cpp
+++ b/Targets/LPC177x_LPC178x/LPC17_Display.cpp
@@ -368,6 +368,8 @@ bool m_LPC17_DisplayEnable = false;
 uint32_t displayInitializeCount = 0;
 
 uint16_t* m_LPC17_Display_VituralRam = nullptr;
+uint32_t* m_LPC17_Display_buffer = nullptr;
+
 size_t m_LPC17_DisplayBufferSize = 0;
 
 uint8_t m_LPC17_Display_TextBuffer[LCD_MAX_COLUMN][LCD_MAX_ROW];
@@ -625,12 +627,12 @@ const LPC17_Gpio_Pin displayEnablePin = LPC17_DISPLAY_ENABLE_PIN;
 bool  LPC17_Display_SetPinConfiguration(int32_t controllerIndex, bool enable) {
     if (enable) {
         // Open multi lcd pins
-        if (!LPC17_GpioInternal_OpenMultiPins(displayPins[controllerIndex], 19)) {
+        if (!LPC17_GpioInternal_OpenMultiPins(displayPins[controllerIndex], SIZEOF_ARRAY(displayPins[controllerIndex]))) {
             return false;
         }
 
         // Set configuration
-        for (auto i = 0; i < SIZEOF_ARRAY(displayPins); i++) {
+        for (auto i = 0; i < SIZEOF_ARRAY(displayPins[controllerIndex]); i++) {
             LPC17_GpioInternal_ConfigurePin(displayPins[controllerIndex][i].number, LPC17_Gpio_Direction::Input, displayPins[controllerIndex][i].pinFunction, LPC17_Gpio_ResistorMode::Inactive, LPC17_Gpio_Hysteresis::Disable, LPC17_Gpio_InputPolarity::NotInverted, LPC17_Gpio_SlewRate::StandardMode, LPC17_Gpio_OutputType::PushPull);
         }
 
@@ -641,14 +643,14 @@ bool  LPC17_Display_SetPinConfiguration(int32_t controllerIndex, bool enable) {
 
                 return false;
             }
-        }        
+        }
     }
     else {
         for (int32_t i = 0; i < SIZEOF_ARRAY(displayPins); i++) {
             LPC17_GpioInternal_ClosePin(displayPins[controllerIndex][i].number);
         }
 
-        LPC17_GpioInternal_ClosePin(displayEnablePin.number);        
+        LPC17_GpioInternal_ClosePin(displayEnablePin.number);
     }
 
     return true;
@@ -682,34 +684,7 @@ int32_t LPC17_Display_GetOrientation() {
     return m_LPC17_Display_CurrentRotation;
 }
 
-void  LPC17_Display_MemCopy(void *dest, void *src, int32_t size) {
-    const int32_t MEMCOPY_BYTES_ALIGNED = 8;
-
-    uint64_t *from64 = (uint64_t *)src;
-    uint64_t *to64 = (uint64_t *)dest;
-
-    int32_t block = size / MEMCOPY_BYTES_ALIGNED;
-    int32_t remainder = size % MEMCOPY_BYTES_ALIGNED;
-
-    while (block > 0) {
-        *to64++ = *from64++;
-        block--;
-    }
-
-    if (remainder > 0) {
-        uint8_t *from8 = (uint8_t *)from64;
-        uint8_t *to8 = (uint8_t *)to64;
-
-        while (remainder > 0) {
-            *to8++ = *from8++;
-
-            remainder--;
-        }
-    }
-}
-
 void LPC17_Display_BitBltEx(int32_t x, int32_t y, int32_t width, int32_t height, uint32_t data[]) {
-
     int32_t xTo, yTo, xFrom, yFrom;
     int32_t xOffset = x;
     int32_t yOffset = y;
@@ -729,11 +704,11 @@ void LPC17_Display_BitBltEx(int32_t x, int32_t y, int32_t width, int32_t height,
 
         if (xOffset == 0 && yOffset == 0 &&
             width == screenWidth && height == screenHeight) {
-            LPC17_Display_MemCopy(to, from, (screenWidth*screenHeight * 2));
+            memcpy(to, from, (screenWidth*screenHeight * 2));
         }
         else {
             for (yTo = yOffset; yTo < (yOffset + height); yTo++) {
-                LPC17_Display_MemCopy((void*)(to + yTo * screenWidth + xOffset), (void*)(from), (width * 2));
+                memcpy((void*)(to + yTo * screenWidth + xOffset), (void*)(from), (width * 2));
                 from += width;
             }
         }
@@ -863,12 +838,12 @@ TinyCLR_Result LPC17_Display_Release(const TinyCLR_Display_Controller* self) {
 
         m_LPC17_DisplayEnable = false;
 
-        if (m_LPC17_Display_VituralRam != nullptr) {
+        if (m_LPC17_Display_buffer != nullptr) {
             auto memoryProvider = (const TinyCLR_Memory_Manager*)apiManager->FindDefault(apiManager, TinyCLR_Api_Type::MemoryManager);
 
-            memoryProvider->Free(memoryProvider, m_LPC17_Display_VituralRam);
+            memoryProvider->Free(memoryProvider, m_LPC17_Display_buffer);
 
-            m_LPC17_Display_VituralRam = nullptr;
+            m_LPC17_Display_buffer = nullptr;
         }
     }
     return TinyCLR_Result::Success;
@@ -931,18 +906,21 @@ TinyCLR_Result LPC17_Display_SetConfiguration(const TinyCLR_Display_Controller* 
 
         auto memoryProvider = (const TinyCLR_Memory_Manager*)apiManager->FindDefault(apiManager, TinyCLR_Api_Type::MemoryManager);
 
-        if (m_LPC17_Display_VituralRam != nullptr) {
-            memoryProvider->Free(memoryProvider, m_LPC17_Display_VituralRam);
+        if (m_LPC17_Display_buffer != nullptr) {
+            memoryProvider->Free(memoryProvider, m_LPC17_Display_buffer);
 
-            m_LPC17_Display_VituralRam = nullptr;
+            m_LPC17_Display_buffer = nullptr;
         }
 
-        m_LPC17_Display_VituralRam = (uint16_t*)((uint8_t*)memoryProvider->Allocate(memoryProvider, m_LPC17_DisplayBufferSize));
+        m_LPC17_Display_buffer = (uint32_t*)memoryProvider->Allocate(memoryProvider, m_LPC17_DisplayBufferSize + 8);
 
-        if (m_LPC17_Display_VituralRam == nullptr) {
+        if (m_LPC17_Display_buffer == nullptr) {
             return TinyCLR_Result::OutOfMemory;
         }
 
+        m_LPC17_Display_VituralRam = (uint16_t*)((((uint32_t)m_LPC17_Display_buffer) + (7)) & (~((uint32_t)(7))));
+
+        // Set displayEnablePin following m_LPC17_DisplayOutputEnableIsFixed
         if (displayEnablePin.number != PIN_NONE) {
             if (m_LPC17_DisplayOutputEnableIsFixed)
                 LPC17_GpioInternal_EnableOutputPin(displayEnablePin.number, m_LPC17_DisplayOutputEnablePolarity);
@@ -1056,7 +1034,9 @@ void LPC17_Display_AddApi(const TinyCLR_Api_Manager* apiManager) {
         apiManager->Add(apiManager, &displayApi[i]);
     }
 
-    m_LPC17_Display_VituralRam = nullptr;
+    displayInitializeCount = 0;
+    m_LPC17_Display_buffer = nullptr;
+    m_LPC17_DisplayEnable = false;
 
     apiManager->SetDefaultName(apiManager, TinyCLR_Api_Type::DisplayController, displayApi[0].Name);
 }
@@ -1069,5 +1049,6 @@ void LPC17_Display_Reset() {
 
     m_LPC17_DisplayEnable = false;
     displayInitializeCount = 0;
+    m_LPC17_Display_buffer = nullptr;
 }
 

--- a/Targets/LPC23xx_LPC24xx/LPC24_Display.cpp
+++ b/Targets/LPC23xx_LPC24xx/LPC24_Display.cpp
@@ -398,6 +398,8 @@ bool m_LPC24_DisplayEnable = false;
 
 uint32_t displayInitializeCount = 0;
 uint16_t* m_LPC24_Display_VituralRam = nullptr;
+uint32_t* m_LPC24_Display_buffer = nullptr;
+
 size_t m_LPC24_DisplayBufferSize = 0;
 uint8_t m_LPC24_Display_TextBuffer[LCD_MAX_COLUMN][LCD_MAX_ROW];
 
@@ -662,12 +664,12 @@ bool  LPC24_Display_SetPinConfiguration(bool enable) {
         LPC24XX::PCB().PINSEL11 = (5 << 1) | 1;
         LPC24XX::PCB().PINSEL10 = 0;
         // Open multi lcd pins
-        if (!LPC24_GpioInternal_OpenMultiPins(displayPins[controllerIndex], 19)) {
+        if (!LPC24_GpioInternal_OpenMultiPins(displayPins[controllerIndex], SIZEOF_ARRAY(displayPins[controllerIndex]))) {
             return false;
         }
 
         // Set configuration
-        for (auto i = 0; i < SIZEOF_ARRAY(displayPins); i++) {
+        for (auto i = 0; i < SIZEOF_ARRAY(displayPins[controllerIndex]); i++) {
             LPC24_GpioInternal_ConfigurePin(displayPins[controllerIndex][i].number, LPC24_Gpio_Direction::Input, displayPins[controllerIndex][i].pinFunction, LPC24_Gpio_PinMode::Inactive);
         }
 
@@ -677,14 +679,14 @@ bool  LPC24_Display_SetPinConfiguration(bool enable) {
 
                 return false;
             }
-        }        
+        }
     }
     else {
         for (int32_t i = 0; i < SIZEOF_ARRAY(displayPins); i++) {
             LPC24_GpioInternal_ClosePin(displayPins[controllerIndex][i].number);
         }
 
-        LPC24_GpioInternal_ClosePin(displayEnablePin.number);        
+        LPC24_GpioInternal_ClosePin(displayEnablePin.number);
     }
 
     return true;
@@ -718,32 +720,6 @@ int32_t LPC24_Display_GetOrientation() {
     return m_LPC24_Display_CurrentRotation;
 }
 
-void  LPC24_Display_MemCopy(void *dest, void *src, int32_t size) {
-    const int32_t MEMCOPY_BYTES_ALIGNED = 8;
-
-    uint64_t *from64 = (uint64_t *)src;
-    uint64_t *to64 = (uint64_t *)dest;
-
-    int32_t block = size / MEMCOPY_BYTES_ALIGNED;
-    int32_t remainder = size % MEMCOPY_BYTES_ALIGNED;
-
-    while (block > 0) {
-        *to64++ = *from64++;
-        block--;
-    }
-
-    if (remainder > 0) {
-        uint8_t *from8 = (uint8_t *)from64;
-        uint8_t *to8 = (uint8_t *)to64;
-
-        while (remainder > 0) {
-            *to8++ = *from8++;
-
-            remainder--;
-        }
-    }
-}
-
 void LPC24_Display_BitBltEx(int32_t x, int32_t y, int32_t width, int32_t height, uint32_t data[]) {
 
     int32_t xTo, yTo, xFrom, yFrom;
@@ -765,11 +741,11 @@ void LPC24_Display_BitBltEx(int32_t x, int32_t y, int32_t width, int32_t height,
 
         if (xOffset == 0 && yOffset == 0 &&
             width == screenWidth && height == screenHeight) {
-            LPC24_Display_MemCopy(to, from, (screenWidth*screenHeight * 2));
+            memcpy(to, from, (screenWidth*screenHeight * 2));
         }
         else {
             for (yTo = yOffset; yTo < (yOffset + height); yTo++) {
-                LPC24_Display_MemCopy((void*)(to + yTo * screenWidth + xOffset), (void*)(from), (width * 2));
+                memcpy((void*)(to + yTo * screenWidth + xOffset), (void*)(from), (width * 2));
                 from += width;
             }
         }
@@ -899,12 +875,12 @@ TinyCLR_Result LPC24_Display_Release(const TinyCLR_Display_Controller* self) {
 
         m_LPC24_DisplayEnable = false;
 
-        if (m_LPC24_Display_VituralRam != nullptr) {
+        if (m_LPC24_Display_buffer != nullptr) {
             auto memoryProvider = (const TinyCLR_Memory_Manager*)apiManager->FindDefault(apiManager, TinyCLR_Api_Type::MemoryManager);
 
-            memoryProvider->Free(memoryProvider, m_LPC24_Display_VituralRam);
+            memoryProvider->Free(memoryProvider, m_LPC24_Display_buffer);
 
-            m_LPC24_Display_VituralRam = nullptr;
+            m_LPC24_Display_buffer = nullptr;
         }
     }
     return TinyCLR_Result::Success;
@@ -967,18 +943,21 @@ TinyCLR_Result LPC24_Display_SetConfiguration(const TinyCLR_Display_Controller* 
 
         auto memoryProvider = (const TinyCLR_Memory_Manager*)apiManager->FindDefault(apiManager, TinyCLR_Api_Type::MemoryManager);
 
-        if (m_LPC24_Display_VituralRam != nullptr) {
-            memoryProvider->Free(memoryProvider, m_LPC24_Display_VituralRam);
+        if (m_LPC24_Display_buffer != nullptr) {
+            memoryProvider->Free(memoryProvider, m_LPC24_Display_buffer);
 
-            m_LPC24_Display_VituralRam = nullptr;
+            m_LPC24_Display_buffer = nullptr;
         }
 
-        m_LPC24_Display_VituralRam = (uint16_t*)((uint8_t*)memoryProvider->Allocate(memoryProvider, m_LPC24_DisplayBufferSize));
+        m_LPC24_Display_buffer = (uint32_t*)memoryProvider->Allocate(memoryProvider, m_LPC24_DisplayBufferSize + 8);
 
-        if (m_LPC24_Display_VituralRam == nullptr) {
+        if (m_LPC24_Display_buffer == nullptr) {
             return TinyCLR_Result::OutOfMemory;
         }
 
+        m_LPC24_Display_VituralRam = (uint16_t*)((((uint32_t)m_LPC24_Display_buffer) + (7)) & (~((uint32_t)(7))));
+
+        // Set displayEnablePin following m_LPC24_DisplayOutputEnableIsFixed
         if (displayEnablePin.number != PIN_NONE) {
             if (m_LPC24_DisplayOutputEnableIsFixed)
                 LPC24_GpioInternal_EnableOutputPin(displayEnablePin.number, m_LPC24_DisplayOutputEnablePolarity);
@@ -1092,7 +1071,9 @@ void LPC24_Display_AddApi(const TinyCLR_Api_Manager* apiManager) {
         apiManager->Add(apiManager, &displayApi[i]);
     }
 
-    m_LPC24_Display_VituralRam = nullptr;
+    displayInitializeCount = 0;
+    m_LPC24_Display_buffer = nullptr;
+    m_LPC24_DisplayEnable = false;
 
     apiManager->SetDefaultName(apiManager, TinyCLR_Api_Type::DisplayController, displayApi[0].Name);
 }
@@ -1105,5 +1086,6 @@ void LPC24_Display_Reset() {
 
     m_LPC24_DisplayEnable = false;
     displayInitializeCount = 0;
+    m_LPC24_Display_buffer = nullptr;
 }
 #endif

--- a/Targets/STM32F4xx/STM32F4_Display.cpp
+++ b/Targets/STM32F4xx/STM32F4_Display.cpp
@@ -342,6 +342,7 @@ bool m_STM32F4_DisplayEnable = false;
 uint32_t displayInitializeCount = 0;
 
 uint16_t* m_STM32F4_Display_VituralRam = nullptr;
+uint32_t* m_STM32F4_Display_buffer = nullptr;
 size_t m_STM32F4_DisplayBufferSize = 0;
 
 uint8_t m_STM32F4_Display_TextBuffer[LCD_MAX_COLUMN][LCD_MAX_ROW];
@@ -808,7 +809,7 @@ const STM32F4_Gpio_Pin displayEnablePin = STM32F4_DISPLAY_ENABLE_PIN;
 bool STM32F4_Display_SetPinConfiguration(int32_t controllerIndex, bool enable) {
     if (enable) {
         // Open multi lcd pins
-        if (!STM32F4_GpioInternal_OpenMultiPins(displayPins[controllerIndex], 19)) {
+        if (!STM32F4_GpioInternal_OpenMultiPins(displayPins[controllerIndex], SIZEOF_ARRAY(displayPins[controllerIndex]))) {
             return false;
         }
 
@@ -825,14 +826,14 @@ bool STM32F4_Display_SetPinConfiguration(int32_t controllerIndex, bool enable) {
 
                 return false;
             }
-        }        
+        }
     }
     else {
         for (int32_t i = 0; i < SIZEOF_ARRAY(displayPins[controllerIndex]); i++) {
             STM32F4_GpioInternal_ClosePin(displayPins[controllerIndex][i].number);
         }
 
-        STM32F4_GpioInternal_ClosePin(displayEnablePin.number);        
+        STM32F4_GpioInternal_ClosePin(displayEnablePin.number);
     }
 
     return true;
@@ -867,34 +868,7 @@ int32_t STM32F4_Display_GetOrientation() {
     return m_STM32F4_Display_CurrentRotation;
 }
 
-void  STM32F4_Display_MemCopy(void *dest, void *src, int32_t size) {
-    const int32_t MEMCOPY_BYTES_ALIGNED = 8;
-
-    uint64_t *from64 = (uint64_t *)src;
-    uint64_t *to64 = (uint64_t *)dest;
-
-    int32_t block = size / MEMCOPY_BYTES_ALIGNED;
-    int32_t remainder = size % MEMCOPY_BYTES_ALIGNED;
-
-    while (block > 0) {
-        *to64++ = *from64++;
-        block--;
-    }
-
-    if (remainder > 0) {
-        uint8_t *from8 = (uint8_t *)from64;
-        uint8_t *to8 = (uint8_t *)to64;
-
-        while (remainder > 0) {
-            *to8++ = *from8++;
-
-            remainder--;
-        }
-    }
-}
-
 void STM32F4_Display_BitBltEx(int32_t x, int32_t y, int32_t width, int32_t height, uint32_t data[]) {
-
     int32_t xTo, yTo, xFrom, yFrom;
     int32_t xOffset = x;
     int32_t yOffset = y;
@@ -914,11 +888,11 @@ void STM32F4_Display_BitBltEx(int32_t x, int32_t y, int32_t width, int32_t heigh
 
         if (xOffset == 0 && yOffset == 0 &&
             width == screenWidth && height == screenHeight) {
-            STM32F4_Display_MemCopy(to, from, (screenWidth*screenHeight * 2));
+            memcpy(to, from, (screenWidth*screenHeight * 2));
         }
         else {
             for (yTo = yOffset; yTo < (yOffset + height); yTo++) {
-                STM32F4_Display_MemCopy((void*)(to + yTo * screenWidth + xOffset), (void*)(from), (width * 2));
+                memcpy((void*)(to + yTo * screenWidth + xOffset), (void*)(from), (width * 2));
                 from += width;
             }
         }
@@ -1049,12 +1023,12 @@ TinyCLR_Result STM32F4_Display_Release(const TinyCLR_Display_Controller* self) {
 
         m_STM32F4_DisplayEnable = false;
 
-        if (m_STM32F4_Display_VituralRam != nullptr) {
+        if (m_STM32F4_Display_buffer != nullptr) {
             auto memoryProvider = (const TinyCLR_Memory_Manager*)apiManager->FindDefault(apiManager, TinyCLR_Api_Type::MemoryManager);
 
-            memoryProvider->Free(memoryProvider, m_STM32F4_Display_VituralRam);
+            memoryProvider->Free(memoryProvider, m_STM32F4_Display_buffer);
 
-            m_STM32F4_Display_VituralRam = nullptr;
+            m_STM32F4_Display_buffer = nullptr;
         }
     }
 
@@ -1118,17 +1092,20 @@ TinyCLR_Result STM32F4_Display_SetConfiguration(const TinyCLR_Display_Controller
 
         auto memoryProvider = (const TinyCLR_Memory_Manager*)apiManager->FindDefault(apiManager, TinyCLR_Api_Type::MemoryManager);
 
-        if (m_STM32F4_Display_VituralRam != nullptr) {
-            memoryProvider->Free(memoryProvider, m_STM32F4_Display_VituralRam);
+        if (m_STM32F4_Display_buffer != nullptr) {
+            memoryProvider->Free(memoryProvider, m_STM32F4_Display_buffer);
 
-            m_STM32F4_Display_VituralRam = nullptr;
+            m_STM32F4_Display_buffer = nullptr;
         }
 
-        m_STM32F4_Display_VituralRam = (uint16_t*)((uint8_t*)memoryProvider->Allocate(memoryProvider, m_STM32F4_DisplayBufferSize));
+        m_STM32F4_Display_buffer = (uint32_t*)memoryProvider->Allocate(memoryProvider, m_STM32F4_DisplayBufferSize + 8);
 
-        if (m_STM32F4_Display_VituralRam == nullptr) {
+        if (m_STM32F4_Display_buffer == nullptr) {
             return TinyCLR_Result::OutOfMemory;
         }
+
+        m_STM32F4_Display_VituralRam = (uint16_t*)((((uint32_t)m_STM32F4_Display_buffer) + (7)) & (~((uint32_t)(7))));
+
 
         // Set displayEnablePin following m_STM32F4_DisplayOutputEnableIsFixed
         if (displayEnablePin.number != PIN_NONE) {
@@ -1247,7 +1224,9 @@ void STM32F4_Display_AddApi(const TinyCLR_Api_Manager* apiManager) {
         apiManager->Add(apiManager, &displayApi[i]);
     }
 
-    m_STM32F4_Display_VituralRam = nullptr;
+    displayInitializeCount = 0;
+    m_STM32F4_Display_buffer = nullptr;
+    m_STM32F4_DisplayEnable = false;
 
     apiManager->SetDefaultName(apiManager, TinyCLR_Api_Type::DisplayController, displayApi[0].Name);
 }
@@ -1260,5 +1239,6 @@ void STM32F4_Display_Reset() {
 
     m_STM32F4_DisplayEnable = false;
     displayInitializeCount = 0;
+    m_STM32F4_Display_buffer = nullptr;
 }
 #endif


### PR DESCRIPTION
Fixed #487.