### PR TITLE
Rework uart

### DIFF
--- a/Targets/AT91SAM9Rx64/AT91SAM9Rx64_USART.cpp
+++ b/Targets/AT91SAM9Rx64/AT91SAM9Rx64_USART.cpp
@@ -676,8 +676,8 @@ TinyCLR_Result AT91SAM9Rx64_Uart_Read(const TinyCLR_Uart_Controller* self, uint8
     auto state = reinterpret_cast<UartState*>(self->ApiInfo->State);
     auto controllerIndex = state->controllerIndex;
 
-    if (state->initializeCount == 0 || state->rxBufferSize == 0) {
-        length = 0;
+    if (state->initializeCount == 0) {
+        length = 0; // make sure length is updated
 
         return TinyCLR_Result::NotAvailable;
     }
@@ -716,8 +716,8 @@ TinyCLR_Result AT91SAM9Rx64_Uart_Write(const TinyCLR_Uart_Controller* self, cons
 
     auto controllerIndex = state->controllerIndex;
 
-    if (state->initializeCount == 0 || state->txBufferSize == 0) {
-        length = 0;
+    if (state->initializeCount == 0) {
+        length = 0; // make sure length is updated
 
         return TinyCLR_Result::NotAvailable;
     }

--- a/Targets/AT91SAM9X35/AT91SAM9X35_USART.cpp
+++ b/Targets/AT91SAM9X35/AT91SAM9X35_USART.cpp
@@ -676,8 +676,8 @@ TinyCLR_Result AT91SAM9X35_Uart_Read(const TinyCLR_Uart_Controller* self, uint8_
     auto state = reinterpret_cast<UartState*>(self->ApiInfo->State);
     auto controllerIndex = state->controllerIndex;
 
-    if (state->initializeCount == 0 || state->rxBufferSize == 0) {
-        length = 0;
+    if (state->initializeCount == 0) {
+        length = 0; // make sure length is updated
 
         return TinyCLR_Result::NotAvailable;
     }
@@ -716,8 +716,8 @@ TinyCLR_Result AT91SAM9X35_Uart_Write(const TinyCLR_Uart_Controller* self, const
 
     auto controllerIndex = state->controllerIndex;
 
-    if (state->initializeCount == 0 || state->txBufferSize == 0) {
-        length = 0;
+    if (state->initializeCount == 0) {
+        length = 0; // make sure length is updated
 
         return TinyCLR_Result::NotAvailable;
     }

--- a/Targets/LPC177x_LPC178x/LPC17_USART.cpp
+++ b/Targets/LPC177x_LPC178x/LPC17_USART.cpp
@@ -954,8 +954,8 @@ TinyCLR_Result LPC17_Uart_Read(const TinyCLR_Uart_Controller* self, uint8_t* buf
 
     auto state = reinterpret_cast<UartState*>(self->ApiInfo->State);
 
-    if (state->initializeCount == 0 || state->rxBufferSize == 0) {
-        length = 0;
+    if (state->initializeCount == 0) {
+        length = 0; // make sure length is updated
 
         return TinyCLR_Result::NotAvailable;
     }
@@ -988,8 +988,8 @@ TinyCLR_Result LPC17_Uart_Write(const TinyCLR_Uart_Controller* self, const uint8
 
     auto controllerIndex = state->controllerIndex;
 
-    if (state->initializeCount == 0 || state->txBufferSize == 0) {
-        length = 0;
+    if (state->initializeCount == 0) {
+        length = 0; // make sure length is updated
 
         return TinyCLR_Result::NotAvailable;
     }

--- a/Targets/LPC23xx_LPC24xx/LPC24_USART.cpp
+++ b/Targets/LPC23xx_LPC24xx/LPC24_USART.cpp
@@ -787,8 +787,8 @@ TinyCLR_Result LPC24_Uart_Read(const TinyCLR_Uart_Controller* self, uint8_t* buf
 
     auto state = reinterpret_cast<UartState*>(self->ApiInfo->State);
 
-    if (state->initializeCount == 0 || state->rxBufferSize == 0) {
-        length = 0;
+    if (state->initializeCount == 0) {
+        length = 0; // make sure length is updated
 
         return TinyCLR_Result::NotAvailable;
     }
@@ -821,8 +821,8 @@ TinyCLR_Result LPC24_Uart_Write(const TinyCLR_Uart_Controller* self, const uint8
 
     auto controllerIndex = state->controllerIndex;
 
-    if (state->initializeCount == 0 || state->txBufferSize == 0) {
-        length = 0;
+    if (state->initializeCount == 0) {
+        length = 0; // make sure length is updated
 
         return TinyCLR_Result::NotAvailable;
     }

--- a/Targets/STM32F4xx/STM32F4_UART.cpp
+++ b/Targets/STM32F4xx/STM32F4_UART.cpp
@@ -783,6 +783,8 @@ TinyCLR_Result STM32F4_Uart_Read(const TinyCLR_Uart_Controller* self, uint8_t* b
     auto state = reinterpret_cast<UartState*>(self->ApiInfo->State);
 
     if (state->initializeCount == 0) {
+        length = 0; // make sure length is updated
+
         return TinyCLR_Result::NotAvailable;
     }
 
@@ -815,6 +817,8 @@ TinyCLR_Result STM32F4_Uart_Write(const TinyCLR_Uart_Controller* self, const uin
     int32_t controllerIndex = state->controllerIndex;
 
     if (state->initializeCount == 0) {
+        length = 0; // make sure length is updated
+
         return TinyCLR_Result::NotAvailable;
     }
 

--- a/Targets/STM32F7xx/STM32F7_UART.cpp
+++ b/Targets/STM32F7xx/STM32F7_UART.cpp
@@ -781,6 +781,8 @@ TinyCLR_Result STM32F7_Uart_Read(const TinyCLR_Uart_Controller* self, uint8_t* b
     auto state = reinterpret_cast<UartState*>(self->ApiInfo->State);
 
     if (state->initializeCount == 0) {
+        length = 0; // make sure length is updated
+
         return TinyCLR_Result::NotAvailable;
     }
 
@@ -813,6 +815,7 @@ TinyCLR_Result STM32F7_Uart_Write(const TinyCLR_Uart_Controller* self, const uin
     int32_t controllerIndex = state->controllerIndex;
 
     if (state->initializeCount == 0) {
+        length = 0; // make sure length is updated
         return TinyCLR_Result::NotAvailable;
     }
 


### PR DESCRIPTION
Make sure length is updated to zero in case users don't check TinyCLR Result value.