### PR TITLE
Fixed #527.

### DIFF
--- a/Targets/AT91SAM9X35/AT91SAM9X35_CAN.cpp
+++ b/Targets/AT91SAM9X35/AT91SAM9X35_CAN.cpp
@@ -1301,7 +1301,12 @@ void CopyMessageFromMailBoxToBuffer(uint8_t controllerIndex, uint32_t dwMsr) {
         }
     }
 
-    if (state->can_rx_count > (state->can_rxBufferSize - 3)) {
+    if (state->can_rx_count == state->can_rxBufferSize) { // Raise error full
+        state->errorEventHandler(state->controller, TinyCLR_Can_Error::BufferFull, AT91SAM9X35_Time_GetCurrentProcessorTime());
+
+        return;
+    }
+    else if (state->can_rx_count > state->can_rxBufferSize - 3) { // Raise full event soon when internal buffer has only 3 availble msg left
         state->errorEventHandler(state->controller, TinyCLR_Can_Error::BufferFull, AT91SAM9X35_Time_GetCurrentProcessorTime());
     }
 

--- a/Targets/AT91SAM9X35/AT91SAM9X35_CAN.cpp
+++ b/Targets/AT91SAM9X35/AT91SAM9X35_CAN.cpp
@@ -34,6 +34,8 @@ static const uint32_t canDefaultBuffersSize[] = AT91SAM9X35_CAN_BUFFER_DEFAULT_S
 #define CANMB_NUMBER 8
 #define CAN_NUM_MAILBOX     8
 
+#define CAN_MINIMUM_MESSAGES_LEFT 3
+
 // CAN mail box
 typedef struct {
     uint32_t  CAN_MMR;        /**< \brief (CanMb Offset: 0x0) Mailbox Mode Register */
@@ -1306,7 +1308,7 @@ void CopyMessageFromMailBoxToBuffer(uint8_t controllerIndex, uint32_t dwMsr) {
 
         return;
     }
-    else if (state->can_rx_count > state->can_rxBufferSize - 3) { // Raise full event soon when internal buffer has only 3 availble msg left
+    else if (state->can_rx_count > state->can_rxBufferSize - CAN_MINIMUM_MESSAGES_LEFT) { // Raise full event soon when internal buffer has only 3 availble msg left
         state->errorEventHandler(state->controller, TinyCLR_Can_Error::BufferFull, AT91SAM9X35_Time_GetCurrentProcessorTime());
     }
 
@@ -1915,7 +1917,7 @@ TinyCLR_Result AT91SAM9X35_Can_SetReadBufferSize(const TinyCLR_Can_Controller* s
 
     auto controllerIndex = state->controllerIndex;
 
-    if (size > 3) {
+    if (size > CAN_MINIMUM_MESSAGES_LEFT) {
         state->can_rxBufferSize = size;
         return TinyCLR_Result::Success;
     }

--- a/Targets/LPC177x_LPC178x/LPC17_CAN.cpp
+++ b/Targets/LPC177x_LPC178x/LPC17_CAN.cpp
@@ -2005,7 +2005,7 @@ typedef struct {
 struct CanState {
     int32_t controllerIndex;
 
-    const TinyCLR_Can_Controller* provider;
+    const TinyCLR_Can_Controller* controller;
 
     LPC17_Can_Message *canRxMessagesFifo;
 
@@ -2316,7 +2316,7 @@ void CAN_ISR_Rx(int32_t controllerIndex) {
         else
             C2CMR = 0x04; // release receive buffer
 
-        state->errorEventHandler(state->provider, TinyCLR_Can_Error::BufferFull, LPC17_Time_GetCurrentProcessorTime());
+        state->errorEventHandler(state->controller, TinyCLR_Can_Error::BufferFull, LPC17_Time_GetCurrentProcessorTime());
 
         return;
     }
@@ -2372,7 +2372,7 @@ void CAN_ISR_Rx(int32_t controllerIndex) {
         state->can_rx_in = 0;
     }
 
-    state->messageReceivedEventHandler(state->provider, state->can_rx_count, LPC17_Time_GetCurrentProcessorTime());
+    state->messageReceivedEventHandler(state->controller, state->can_rx_count, LPC17_Time_GetCurrentProcessorTime());
 }
 void LPC17_Can_RxInterruptHandler(void *param) {
     uint32_t status = CANRxSR;
@@ -2391,14 +2391,14 @@ void LPC17_Can_RxInterruptHandler(void *param) {
         CAN_ISR_Rx(controllerIndex);
 
         if (c1 & (1 << 3)) {
-            state->errorEventHandler(state->provider, TinyCLR_Can_Error::Overrun, LPC17_Time_GetCurrentProcessorTime());
+            state->errorEventHandler(state->controller, TinyCLR_Can_Error::Overrun, LPC17_Time_GetCurrentProcessorTime());
         }
         if (c1 & (1 << 5)) {
-            state->errorEventHandler(state->provider, TinyCLR_Can_Error::Passive, LPC17_Time_GetCurrentProcessorTime());
+            state->errorEventHandler(state->controller, TinyCLR_Can_Error::Passive, LPC17_Time_GetCurrentProcessorTime());
         }
         if (c1 & (1 << 7)) {
             C1MOD = 1;    // Reset CAN
-            state->errorEventHandler(state->provider, TinyCLR_Can_Error::BusOff, LPC17_Time_GetCurrentProcessorTime());
+            state->errorEventHandler(state->controller, TinyCLR_Can_Error::BusOff, LPC17_Time_GetCurrentProcessorTime());
         }
 
     }
@@ -2412,14 +2412,14 @@ void LPC17_Can_RxInterruptHandler(void *param) {
         CAN_ISR_Rx(controllerIndex);
 
         if (c2 & (1 << 3)) {
-            state->errorEventHandler(state->provider, TinyCLR_Can_Error::Overrun, LPC17_Time_GetCurrentProcessorTime());
+            state->errorEventHandler(state->controller, TinyCLR_Can_Error::Overrun, LPC17_Time_GetCurrentProcessorTime());
         }
         if (c2 & (1 << 5)) {
-            state->errorEventHandler(state->provider, TinyCLR_Can_Error::Passive, LPC17_Time_GetCurrentProcessorTime());
+            state->errorEventHandler(state->controller, TinyCLR_Can_Error::Passive, LPC17_Time_GetCurrentProcessorTime());
         }
         if (c2 & (1 << 7)) {
             C2MOD = 1;    // Reset CAN
-            state->errorEventHandler(state->provider, TinyCLR_Can_Error::BusOff, LPC17_Time_GetCurrentProcessorTime());
+            state->errorEventHandler(state->controller, TinyCLR_Can_Error::BusOff, LPC17_Time_GetCurrentProcessorTime());
         }
     }
 }
@@ -2445,7 +2445,7 @@ TinyCLR_Result LPC17_Can_Acquire(const TinyCLR_Can_Controller* self) {
         state->can_rx_out = 0;
         state->baudrate = 0;
         state->can_rxBufferSize = canDefaultBuffersSize[controllerIndex];
-        state->provider = self;
+        state->controller = self;
         state->enable = false;
 
         state->canDataFilter.matchFiltersSize = 0;

--- a/Targets/LPC177x_LPC178x/LPC17_CAN.cpp
+++ b/Targets/LPC177x_LPC178x/LPC17_CAN.cpp
@@ -2310,7 +2310,7 @@ void CAN_ISR_Rx(int32_t controllerIndex) {
         }
     }
 
-    if (state->can_rx_count > (state->can_rxBufferSize - 3)) {
+    if (state->can_rx_count == state->can_rxBufferSize) { // Raise error full
         if (controllerIndex == 0)
             C1CMR = 0x04; // release receive buffer
         else
@@ -2319,6 +2319,9 @@ void CAN_ISR_Rx(int32_t controllerIndex) {
         state->errorEventHandler(state->provider, TinyCLR_Can_Error::BufferFull, LPC17_Time_GetCurrentProcessorTime());
 
         return;
+    }
+    else if (state->can_rx_count > state->can_rxBufferSize - 3) { // Raise full event soon when internal buffer has only 3 availble msg left
+        state->errorEventHandler(state->controller, TinyCLR_Can_Error::BufferFull, LPC17_Time_GetCurrentProcessorTime());
     }
 
     // initialize destination pointer

--- a/Targets/LPC177x_LPC178x/LPC17_CAN.cpp
+++ b/Targets/LPC177x_LPC178x/LPC17_CAN.cpp
@@ -24,6 +24,8 @@
 
 static const uint32_t canDefaultBuffersSize[] = LPC17_CAN_BUFFER_DEFAULT_SIZE;
 
+#define CAN_MINIMUM_MESSAGES_LEFT 3
+
 #define CAN_TRANSFER_TIMEOUT 0xFFFF
 
 #define CAN_MEM_BASE        0xE0038000
@@ -2320,7 +2322,7 @@ void CAN_ISR_Rx(int32_t controllerIndex) {
 
         return;
     }
-    else if (state->can_rx_count > state->can_rxBufferSize - 3) { // Raise full event soon when internal buffer has only 3 availble msg left
+    else if (state->can_rx_count > state->can_rxBufferSize - CAN_MINIMUM_MESSAGES_LEFT) { // Raise full event soon when internal buffer has only 3 availble msg left
         state->errorEventHandler(state->controller, TinyCLR_Can_Error::BufferFull, LPC17_Time_GetCurrentProcessorTime());
     }
 
@@ -2827,7 +2829,7 @@ TinyCLR_Result LPC17_Can_SetReadBufferSize(const TinyCLR_Can_Controller* self, s
     auto state = reinterpret_cast<CanState*>(self->ApiInfo->State);
     auto controllerIndex = state->controllerIndex;
 
-    if (size > 3) {
+    if (size > CAN_MINIMUM_MESSAGES_LEFT) {
         state->can_rxBufferSize = size;
         return TinyCLR_Result::Success;
     }

--- a/Targets/LPC23xx_LPC24xx/LPC24_CAN.cpp
+++ b/Targets/LPC23xx_LPC24xx/LPC24_CAN.cpp
@@ -2006,7 +2006,7 @@ typedef struct {
 struct CanState {
     int32_t controllerIndex;
 
-    const TinyCLR_Can_Controller* provider;
+    const TinyCLR_Can_Controller* controller;
 
     LPC24_Can_Message *canRxMessagesFifo;
 
@@ -2317,7 +2317,7 @@ void CAN_ISR_Rx(int32_t controllerIndex) {
         else
             C2CMR = 0x04; // release receive buffer
 
-        state->errorEventHandler(state->provider, TinyCLR_Can_Error::BufferFull, LPC24_Time_GetCurrentProcessorTime());
+        state->errorEventHandler(state->controller, TinyCLR_Can_Error::BufferFull, LPC24_Time_GetCurrentProcessorTime());
 
         return;
     }
@@ -2373,7 +2373,7 @@ void CAN_ISR_Rx(int32_t controllerIndex) {
         state->can_rx_in = 0;
     }
 
-    state->messageReceivedEventHandler(state->provider, state->can_rx_count, t);
+    state->messageReceivedEventHandler(state->controller, state->can_rx_count, t);
 }
 void LPC24_Can_RxInterruptHandler(void *param) {
     uint32_t status = CANRxSR;
@@ -2392,14 +2392,14 @@ void LPC24_Can_RxInterruptHandler(void *param) {
         CAN_ISR_Rx(controllerIndex);
 
         if (c1 & (1 << 3)) {
-            state->errorEventHandler(state->provider, TinyCLR_Can_Error::Overrun, LPC24_Time_GetCurrentProcessorTime());
+            state->errorEventHandler(state->controller, TinyCLR_Can_Error::Overrun, LPC24_Time_GetCurrentProcessorTime());
         }
         if (c1 & (1 << 5)) {
-            state->errorEventHandler(state->provider, TinyCLR_Can_Error::Passive, LPC24_Time_GetCurrentProcessorTime());
+            state->errorEventHandler(state->controller, TinyCLR_Can_Error::Passive, LPC24_Time_GetCurrentProcessorTime());
         }
         if (c1 & (1 << 7)) {
             C1MOD = 1;    // Reset CAN
-            state->errorEventHandler(state->provider, TinyCLR_Can_Error::BusOff, LPC24_Time_GetCurrentProcessorTime());
+            state->errorEventHandler(state->controller, TinyCLR_Can_Error::BusOff, LPC24_Time_GetCurrentProcessorTime());
         }
 
     }
@@ -2413,14 +2413,14 @@ void LPC24_Can_RxInterruptHandler(void *param) {
         CAN_ISR_Rx(controllerIndex);
 
         if (c2 & (1 << 3)) {
-            state->errorEventHandler(state->provider, TinyCLR_Can_Error::Overrun, LPC24_Time_GetCurrentProcessorTime());
+            state->errorEventHandler(state->controller, TinyCLR_Can_Error::Overrun, LPC24_Time_GetCurrentProcessorTime());
         }
         if (c2 & (1 << 5)) {
-            state->errorEventHandler(state->provider, TinyCLR_Can_Error::Passive, LPC24_Time_GetCurrentProcessorTime());
+            state->errorEventHandler(state->controller, TinyCLR_Can_Error::Passive, LPC24_Time_GetCurrentProcessorTime());
         }
         if (c2 & (1 << 7)) {
             C2MOD = 1;    // Reset CAN
-            state->errorEventHandler(state->provider, TinyCLR_Can_Error::BusOff, LPC24_Time_GetCurrentProcessorTime());
+            state->errorEventHandler(state->controller, TinyCLR_Can_Error::BusOff, LPC24_Time_GetCurrentProcessorTime());
         }
     }
 }
@@ -2446,7 +2446,7 @@ TinyCLR_Result LPC24_Can_Acquire(const TinyCLR_Can_Controller* self) {
         state->can_rx_out = 0;
         state->baudrate = 0;
         state->can_rxBufferSize = canDefaultBuffersSize[controllerIndex];
-        state->provider = self;
+        state->controller = self;
         state->enable = false;
 
         state->canDataFilter.matchFiltersSize = 0;

--- a/Targets/LPC23xx_LPC24xx/LPC24_CAN.cpp
+++ b/Targets/LPC23xx_LPC24xx/LPC24_CAN.cpp
@@ -2321,6 +2321,9 @@ void CAN_ISR_Rx(int32_t controllerIndex) {
 
         return;
     }
+    else if (state->can_rx_count > state->can_rxBufferSize - 3) { // Raise full event soon when internal buffer has only 3 availble msg left
+        state->errorEventHandler(state->controller, TinyCLR_Can_Error::BufferFull, LPC24_Time_GetCurrentProcessorTime());
+    }
 
     // initialize destination pointer
     LPC24_Can_Message *can_msg = &state->canRxMessagesFifo[state->can_rx_in];

--- a/Targets/LPC23xx_LPC24xx/LPC24_CAN.cpp
+++ b/Targets/LPC23xx_LPC24xx/LPC24_CAN.cpp
@@ -24,6 +24,8 @@
 
 static const uint32_t canDefaultBuffersSize[] = LPC24_CAN_BUFFER_DEFAULT_SIZE;
 
+#define CAN_MINIMUM_MESSAGES_LEFT 3
+
 #define CAN_TRANSFER_TIMEOUT 0xFFFF
 
 #define CAN_MEM_BASE        0xE0038000
@@ -2321,7 +2323,7 @@ void CAN_ISR_Rx(int32_t controllerIndex) {
 
         return;
     }
-    else if (state->can_rx_count > state->can_rxBufferSize - 3) { // Raise full event soon when internal buffer has only 3 availble msg left
+    else if (state->can_rx_count > state->can_rxBufferSize - CAN_MINIMUM_MESSAGES_LEFT) { // Raise full event soon when internal buffer has only 3 availble msg left
         state->errorEventHandler(state->controller, TinyCLR_Can_Error::BufferFull, LPC24_Time_GetCurrentProcessorTime());
     }
 
@@ -2833,7 +2835,7 @@ TinyCLR_Result LPC24_Can_SetReadBufferSize(const TinyCLR_Can_Controller* self, s
     auto state = reinterpret_cast<CanState*>(self->ApiInfo->State);
     auto controllerIndex = state->controllerIndex;
 
-    if (size > 3) {
+    if (size > CAN_MINIMUM_MESSAGES_LEFT) {
         state->can_rxBufferSize = size;
         return TinyCLR_Result::Success;
     }

--- a/Targets/STM32F4xx/STM32F4_CAN.cpp
+++ b/Targets/STM32F4xx/STM32F4_CAN.cpp
@@ -300,7 +300,7 @@ typedef struct {
 struct CanState {
     int32_t controllerIndex;
 
-    const TinyCLR_Can_Controller* provider;
+    const TinyCLR_Can_Controller* controller;
 
     STM32F4_Can_Message *canRxMessagesFifo;
 
@@ -992,25 +992,25 @@ bool CAN_ErrorHandler(uint8_t controllerIndex) {
 
     if (CAN_GetITStatus(CANx, CAN_IT_FF0)) {
         CAN_ClearITPendingBit(CANx, CAN_IT_FF0);
-        state->errorEventHandler(state->provider, TinyCLR_Can_Error::BufferFull, STM32F4_Time_GetCurrentProcessorTime());
+        state->errorEventHandler(state->controller, TinyCLR_Can_Error::BufferFull, STM32F4_Time_GetCurrentProcessorTime());
 
         return true;
     }
     else if (CAN_GetITStatus(CANx, CAN_IT_FOV0)) {
         CAN_ClearITPendingBit(CANx, CAN_IT_FOV0);
-        state->errorEventHandler(state->provider, TinyCLR_Can_Error::Overrun, STM32F4_Time_GetCurrentProcessorTime());
+        state->errorEventHandler(state->controller, TinyCLR_Can_Error::Overrun, STM32F4_Time_GetCurrentProcessorTime());
 
         return true;
     }
     else if (CAN_GetITStatus(CANx, CAN_IT_BOF)) {
         CAN_ClearITPendingBit(CANx, CAN_IT_BOF);
-        state->errorEventHandler(state->provider, TinyCLR_Can_Error::BusOff, STM32F4_Time_GetCurrentProcessorTime());
+        state->errorEventHandler(state->controller, TinyCLR_Can_Error::BusOff, STM32F4_Time_GetCurrentProcessorTime());
 
         return true;
     }
     else if (CAN_GetITStatus(CANx, CAN_IT_EPV)) {
         CAN_ClearITPendingBit(CANx, CAN_IT_EPV);
-        state->errorEventHandler(state->provider, TinyCLR_Can_Error::Passive, STM32F4_Time_GetCurrentProcessorTime());
+        state->errorEventHandler(state->controller, TinyCLR_Can_Error::Passive, STM32F4_Time_GetCurrentProcessorTime());
 
         return true;
     }
@@ -1020,13 +1020,13 @@ bool CAN_ErrorHandler(uint8_t controllerIndex) {
     }
     else if (CAN_GetITStatus(CANx, CAN_IT_ERR)) {
         CAN_ClearITPendingBit(CANx, CAN_IT_ERR);
-        state->errorEventHandler(state->provider, TinyCLR_Can_Error::Passive, STM32F4_Time_GetCurrentProcessorTime());
+        state->errorEventHandler(state->controller, TinyCLR_Can_Error::Passive, STM32F4_Time_GetCurrentProcessorTime());
 
         return true;
     }
     else if (CAN_GetITStatus(CANx, CAN_IT_EWG)) {
         CAN_ClearITPendingBit(CANx, CAN_IT_EWG);
-        state->errorEventHandler(state->provider, TinyCLR_Can_Error::Passive, STM32F4_Time_GetCurrentProcessorTime());
+        state->errorEventHandler(state->controller, TinyCLR_Can_Error::Passive, STM32F4_Time_GetCurrentProcessorTime());
     }
 
     return false;
@@ -1210,7 +1210,7 @@ void STM32_Can_RxInterruptHandler(int32_t controllerIndex) {
         state->can_rx_in = 0;
     }
 
-    state->messageReceivedEventHandler(state->provider, state->can_rx_count, t);
+    state->messageReceivedEventHandler(state->controller, state->can_rx_count, t);
 
     return;
 }
@@ -1252,7 +1252,7 @@ TinyCLR_Result STM32F4_Can_Acquire(const TinyCLR_Can_Controller* self) {
         state->can_rx_out = 0;
         state->baudrate = 0;
         state->can_rxBufferSize = canDefaultBuffersSize[controllerIndex];
-        state->provider = self;
+        state->controller = self;
         state->enable = false;
 
         state->canRxMessagesFifo = nullptr;

--- a/Targets/STM32F4xx/STM32F4_CAN.cpp
+++ b/Targets/STM32F4xx/STM32F4_CAN.cpp
@@ -20,6 +20,8 @@
 
 #ifdef INCLUDE_CAN
 
+#define CAN_MINIMUM_MESSAGES_LEFT 3
+
 #define CAN_TRANSFER_TIMEOUT 0xFFFF
 
 #define CAN_Mode_Normal             ((uint8_t)0x00)  /*!< normal mode */
@@ -1095,7 +1097,7 @@ TinyCLR_Result STM32F4_Can_SetReadBufferSize(const TinyCLR_Can_Controller* self,
 
     int32_t controllerIndex = state->controllerIndex;
 
-    if (size > 3) {
+    if (size > CAN_MINIMUM_MESSAGES_LEFT) {
         state->can_rxBufferSize = size;
         return TinyCLR_Result::Success;
     }
@@ -1179,7 +1181,7 @@ void STM32_Can_RxInterruptHandler(int32_t controllerIndex) {
 
         return;
     }
-    else if (state->can_rx_count > state->can_rxBufferSize - 3) { // Raise full event soon when internal buffer has only 3 availble msg left
+    else if (state->can_rx_count > state->can_rxBufferSize - CAN_MINIMUM_MESSAGES_LEFT) { // Raise full event soon when internal buffer has only 3 availble msg left
         state->errorEventHandler(state->controller, TinyCLR_Can_Error::BufferFull, STM32F4_Time_GetCurrentProcessorTime());
     }
 

--- a/Targets/STM32F4xx/STM32F4_CAN.cpp
+++ b/Targets/STM32F4xx/STM32F4_CAN.cpp
@@ -1174,8 +1174,13 @@ void STM32_Can_RxInterruptHandler(int32_t controllerIndex) {
         }
     }
 
-    if (state->can_rx_count > state->can_rxBufferSize - 3) {
+    if (state->can_rx_count == state->can_rxBufferSize) { // Return if internal buffer is full
+        state->errorEventHandler(state->controller, TinyCLR_Can_Error::BufferFull, STM32F4_Time_GetCurrentProcessorTime());
+
         return;
+    }
+    else if (state->can_rx_count > state->can_rxBufferSize - 3) { // Raise full event soon when internal buffer has only 3 availble msg left
+        state->errorEventHandler(state->controller, TinyCLR_Can_Error::BufferFull, STM32F4_Time_GetCurrentProcessorTime());
     }
 
     STM32F4_Can_Message *can_msg = &state->canRxMessagesFifo[state->can_rx_in];

--- a/Targets/STM32F7xx/STM32F7_CAN.cpp
+++ b/Targets/STM32F7xx/STM32F7_CAN.cpp
@@ -20,6 +20,8 @@
 
 #ifdef INCLUDE_CAN
 
+#define CAN_MINIMUM_MESSAGES_LEFT 3
+
 #define CAN_TRANSFER_TIMEOUT 0xFFFF
 
 #define CAN_Mode_Normal             ((uint8_t)0x00)  /*!< normal mode */
@@ -1095,7 +1097,7 @@ TinyCLR_Result STM32F7_Can_SetReadBufferSize(const TinyCLR_Can_Controller* self,
 
     int32_t controllerIndex = state->controllerIndex;
 
-    if (size > 3) {
+    if (size > CAN_MINIMUM_MESSAGES_LEFT) {
         state->can_rxBufferSize = size;
         return TinyCLR_Result::Success;
     }
@@ -1179,7 +1181,7 @@ void STM32_Can_RxInterruptHandler(int32_t controllerIndex) {
 
         return;
     }
-    else if (state->can_rx_count > state->can_rxBufferSize - 3) { // Raise full event soon when internal buffer has only 3 availble msg left
+    else if (state->can_rx_count > state->can_rxBufferSize - CAN_MINIMUM_MESSAGES_LEFT) { // Raise full event soon when internal buffer has only 3 availble msg left
         state->errorEventHandler(state->controller, TinyCLR_Can_Error::BufferFull, STM32F7_Time_GetCurrentProcessorTime());
     }
 

--- a/Targets/STM32F7xx/STM32F7_CAN.cpp
+++ b/Targets/STM32F7xx/STM32F7_CAN.cpp
@@ -300,7 +300,7 @@ typedef struct {
 struct CanState {
     int32_t controllerIndex;
 
-    const TinyCLR_Can_Controller* provider;
+    const TinyCLR_Can_Controller* controller;
 
     STM32F7_Can_Message *canRxMessagesFifo;
 
@@ -992,25 +992,25 @@ bool CAN_ErrorHandler(uint8_t controllerIndex) {
 
     if (CAN_GetITStatus(CANx, CAN_IT_FF0)) {
         CAN_ClearITPendingBit(CANx, CAN_IT_FF0);
-        state->errorEventHandler(state->provider, TinyCLR_Can_Error::BufferFull, STM32F7_Time_GetCurrentProcessorTime());
+        state->errorEventHandler(state->controller, TinyCLR_Can_Error::BufferFull, STM32F7_Time_GetCurrentProcessorTime());
 
         return true;
     }
     else if (CAN_GetITStatus(CANx, CAN_IT_FOV0)) {
         CAN_ClearITPendingBit(CANx, CAN_IT_FOV0);
-        state->errorEventHandler(state->provider, TinyCLR_Can_Error::Overrun, STM32F7_Time_GetCurrentProcessorTime());
+        state->errorEventHandler(state->controller, TinyCLR_Can_Error::Overrun, STM32F7_Time_GetCurrentProcessorTime());
 
         return true;
     }
     else if (CAN_GetITStatus(CANx, CAN_IT_BOF)) {
         CAN_ClearITPendingBit(CANx, CAN_IT_BOF);
-        state->errorEventHandler(state->provider, TinyCLR_Can_Error::BusOff, STM32F7_Time_GetCurrentProcessorTime());
+        state->errorEventHandler(state->controller, TinyCLR_Can_Error::BusOff, STM32F7_Time_GetCurrentProcessorTime());
 
         return true;
     }
     else if (CAN_GetITStatus(CANx, CAN_IT_EPV)) {
         CAN_ClearITPendingBit(CANx, CAN_IT_EPV);
-        state->errorEventHandler(state->provider, TinyCLR_Can_Error::Passive, STM32F7_Time_GetCurrentProcessorTime());
+        state->errorEventHandler(state->controller, TinyCLR_Can_Error::Passive, STM32F7_Time_GetCurrentProcessorTime());
 
         return true;
     }
@@ -1020,13 +1020,13 @@ bool CAN_ErrorHandler(uint8_t controllerIndex) {
     }
     else if (CAN_GetITStatus(CANx, CAN_IT_ERR)) {
         CAN_ClearITPendingBit(CANx, CAN_IT_ERR);
-        state->errorEventHandler(state->provider, TinyCLR_Can_Error::Passive, STM32F7_Time_GetCurrentProcessorTime());
+        state->errorEventHandler(state->controller, TinyCLR_Can_Error::Passive, STM32F7_Time_GetCurrentProcessorTime());
 
         return true;
     }
     else if (CAN_GetITStatus(CANx, CAN_IT_EWG)) {
         CAN_ClearITPendingBit(CANx, CAN_IT_EWG);
-        state->errorEventHandler(state->provider, TinyCLR_Can_Error::Passive, STM32F7_Time_GetCurrentProcessorTime());
+        state->errorEventHandler(state->controller, TinyCLR_Can_Error::Passive, STM32F7_Time_GetCurrentProcessorTime());
     }
 
     return false;
@@ -1210,7 +1210,7 @@ void STM32_Can_RxInterruptHandler(int32_t controllerIndex) {
         state->can_rx_in = 0;
     }
 
-    state->messageReceivedEventHandler(state->provider, state->can_rx_count, t);
+    state->messageReceivedEventHandler(state->controller, state->can_rx_count, t);
 
     return;
 }
@@ -1252,7 +1252,7 @@ TinyCLR_Result STM32F7_Can_Acquire(const TinyCLR_Can_Controller* self) {
         state->can_rx_out = 0;
         state->baudrate = 0;
         state->can_rxBufferSize = canDefaultBuffersSize[controllerIndex];
-        state->provider = self;
+        state->controller = self;
         state->enable = false;
 
         state->canRxMessagesFifo = nullptr;


### PR DESCRIPTION
- Receive message until max buffer, but raise full event when max buffer - CAN_MINIMUM_MESSAGES_LEFT to warning lost messages.