### PR TITLE
Rename Stopbit on STM32

### DIFF
--- a/Targets/STM32F4xx/STM32F4_UART.cpp
+++ b/Targets/STM32F4xx/STM32F4_UART.cpp
@@ -19,8 +19,8 @@
 
 #define USART_EVENT_POST_DEBOUNCE_TICKS (10 * 10000) // 10ms between each events
 // StopBits
-#define USART_STOP_BITS_NONE          0
-#define USART_STOP_BITS_ONE           1
+#define USART_STOP_BITS_ONE           0
+#define USART_STOP_BITS_HALF          1
 #define USART_STOP_BITS_TWO           2
 #define USART_STOP_BITS_ONEPOINTFIVE  3
 
@@ -514,7 +514,7 @@ TinyCLR_Result STM32F4_Uart_SetActiveSettings(const TinyCLR_Uart_Controller* sel
     state->portReg->CR1 = ctrl_cr1;
 
 
-    uint32_t stopbit = USART_STOP_BITS_NONE;
+    uint32_t stopbit = USART_STOP_BITS_ONE;
 
     switch (stopBits) {
     case TinyCLR_Uart_StopBitCount::OnePointFive:

--- a/Targets/STM32F7xx/STM32F7_UART.cpp
+++ b/Targets/STM32F7xx/STM32F7_UART.cpp
@@ -19,8 +19,8 @@
 
 #define USART_EVENT_POST_DEBOUNCE_TICKS (10 * 10000) // 10ms between each events
 // StopBits
-#define USART_STOP_BITS_NONE          0
-#define USART_STOP_BITS_ONE           1
+#define USART_STOP_BITS_ONE           0
+#define USART_STOP_BITS_HALF          1
 #define USART_STOP_BITS_TWO           2
 #define USART_STOP_BITS_ONEPOINTFIVE  3
 
@@ -515,7 +515,7 @@ TinyCLR_Result STM32F7_Uart_SetActiveSettings(const TinyCLR_Uart_Controller* sel
     state->portReg->CR1 = ctrl_cr1;
 
 
-    uint32_t stopbit = USART_STOP_BITS_NONE;
+    uint32_t stopbit = USART_STOP_BITS_ONE;
 
     switch (stopBits) {
     case TinyCLR_Uart_StopBitCount::OnePointFive:


### PR DESCRIPTION
There is no Stopbit None. STM32 has only 1, 0.5, 2, 1.5 match to orders 0,1,2,3.

LPC and AT91 are fine.


